### PR TITLE
minetest 0.4 compatibility

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -303,6 +303,6 @@ end
 
 function unified_inventory.is_creative(playername)
 	return minetest.check_player_privs(playername, {creative=true})
-	or minetest.settings.get_bool("creative_mode")
+	or minetest.settings:get_bool("creative_mode")
 end
 

--- a/init.lua
+++ b/init.lua
@@ -47,7 +47,7 @@ unified_inventory = {
 	lite_mode = minetest.settings.get_bool("unified_inventory_lite"),
 	
 	-- Trash enabled
-	trash_enabled = minetest.settings.get_bool("unified_inventory_trash", false),
+	trash_enabled = (minetest.settings.get_bool("unified_inventory_trash") ~= false),
 
 	pagecols = 8,
 	pagerows = 10,
@@ -80,7 +80,7 @@ dofile(modpath.."/internal.lua")
 dofile(modpath.."/callbacks.lua")
 dofile(modpath.."/register.lua")
 
-if minetest.settings.get_bool("unified_inventory_bags", false) then
+if minetest.settings.get_bool("unified_inventory_bags") ~= false then
 	dofile(modpath.."/bags.lua")
 end
 

--- a/init.lua
+++ b/init.lua
@@ -44,10 +44,10 @@ unified_inventory = {
 	fgettext = function(...) return minetest.formspec_escape(mygettext(...)) end,
 
 	-- "Lite" mode
-	lite_mode = minetest.settings.get_bool("unified_inventory_lite"),
+	lite_mode = minetest.settings:get_bool("unified_inventory_lite"),
 	
 	-- Trash enabled
-	trash_enabled = (minetest.settings.get_bool("unified_inventory_trash") ~= false),
+	trash_enabled = (minetest.settings:get_bool("unified_inventory_trash") ~= false),
 
 	pagecols = 8,
 	pagerows = 10,
@@ -80,7 +80,7 @@ dofile(modpath.."/internal.lua")
 dofile(modpath.."/callbacks.lua")
 dofile(modpath.."/register.lua")
 
-if minetest.settings.get_bool("unified_inventory_bags") ~= false then
+if minetest.settings:get_bool("unified_inventory_bags") ~= false then
 	dofile(modpath.."/bags.lua")
 end
 

--- a/register.lua
+++ b/register.lua
@@ -305,7 +305,7 @@ unified_inventory.register_page("craftguide", {
 			formspec = formspec.."image["..no_pos..","..formspecy..";1.1,1.1;ui_no.png]"
 			formspec = formspec..stack_image_button(item_pos, formspecy, 1.1, 1.1, "item_button_"
 			                   ..other_dir[dir].."_", ItemStack(item_name))
-			if player_privs.give == true or player_privs.creative == true or minetest.settings.get_bool("creative_mode") == true then
+			if player_privs.give == true or player_privs.creative == true or minetest.settings:get_bool("creative_mode") == true then
 				formspec = formspec.."label[0,"..(formspecy + 2.10)..";" .. F("Give me:") .. "]"
 						.."button[0,  "..(formspecy + 2.7)..";0.6,0.5;craftguide_giveme_1;1]"
 						.."button[0.6,"..(formspecy + 2.7)..";0.7,0.5;craftguide_giveme_10;10]"
@@ -382,7 +382,7 @@ unified_inventory.register_page("craftguide", {
 					.."button[0.6,"..(formspecy + 1.5)..";0.7,0.5;craftguide_craft_10;10]"
 					.."button[1.3,"..(formspecy + 1.5)..";0.8,0.5;craftguide_craft_max;" .. F("All") .. "]"
 		end
-		if player_privs.give == true or player_privs.creative == true or minetest.settings.get_bool("creative_mode") == true then
+		if player_privs.give == true or player_privs.creative == true or minetest.settings:get_bool("creative_mode") == true then
 			formspec = formspec.."label[0,"..(formspecy + 2.1)..";" .. F("Give me:") .. "]"
 					.."button[0,  "..(formspecy + 2.7)..";0.6,0.5;craftguide_giveme_1;1]"
 					.."button[0.6,"..(formspecy + 2.7)..";0.7,0.5;craftguide_giveme_10;10]"


### PR DESCRIPTION
Using the two-argument get_bool method breaks compatibility with minetest 0.4. Why not still support both 0.4 and 0.5?