### PR TITLE
Allow all players to view items regardless of 'creative' priv

### DIFF
--- a/internal.lua
+++ b/internal.lua
@@ -297,15 +297,13 @@ function unified_inventory.apply_filter(player, filter, search_dir)
 			return string.find(lname, lfilter, 1, true) or string.find(ldesc, lfilter, 1, true)
 		end
 	end
-	local is_creative = unified_inventory.is_creative(player_name)
 	unified_inventory.filtered_items_list[player_name]={}
 	for name, def in pairs(minetest.registered_items) do
 		if (not def.groups.not_in_creative_inventory
 			or def.groups.not_in_creative_inventory == 0)
 		and def.description
 		and def.description ~= ""
-		and ffilter(name, def)
-		and (is_creative or unified_inventory.crafts_for.recipe[def.name]) then
+		and ffilter(name, def) then
 			table.insert(unified_inventory.filtered_items_list[player_name], name)
 		end
 	end


### PR DESCRIPTION
This allows any player to see usages of items found
even if item does not have explicit
recipies themselves.
(ex: default:papyrus, found/grown in wild, can be made into paper)

---

I love this mod, it's the definitive minetest experience. But I never understood why items with no recipes are hidden from players without "creative" priv; just because an item cannot be made with a recipe doesn't mean players don't have access to the item (plants, worldgen, etc.)

Without this change, looking up something like "papyrus" finds nothing because there are no recipes to make papyrus, but it can be found in the world and used to create paper, reed blocks, etc.