### PR TITLE
Delete inventory items via shift-click in creative mode

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -36,6 +36,9 @@ unified_inventory = {
 	-- Trash enabled
 	trash_enabled = (minetest.settings:get_bool("unified_inventory_trash") ~= false),
 
+	trash_use_listring = minetest.settings:get_bool(
+		"unified_inventory_trash_listring"),
+
 	pagecols = 8,
 	pagerows = 10,
 	page_y = 0,

--- a/register.lua
+++ b/register.lua
@@ -176,12 +176,18 @@ unified_inventory.register_page("craft", {
 		formspec = formspec.."listcolors[#00000000;#00000000]"
 		formspec = formspec.."list[current_player;craftpreview;6,"..formspecy..";1,1;]"
 		formspec = formspec.."list[current_player;craft;2,"..formspecy..";3,3;]"
-		if unified_inventory.trash_enabled or unified_inventory.is_creative(player_name) or minetest.get_player_privs(player_name).give then
+		local has_give_or_creative = unified_inventory.is_creative(player_name)
+			or minetest.get_player_privs(player_name).give
+		if has_give_or_creative or unified_inventory.trash_enabled then
 			formspec = formspec.."label[7,"..(formspecy + 1.5)..";" .. F(S("Trash:")) .. "]"
 			formspec = formspec.."background[7,"..(formspecy + 2)..";1,1;ui_single_slot.png]"
 			formspec = formspec.."list[detached:trash;main;7,"..(formspecy + 2)..";1,1;]"
 		end
-		formspec = formspec.."listring[current_name;craft]"
+		if has_give_or_creative and unified_inventory.trash_use_listring then
+			formspec = formspec .. "listring[detached:trash;main]"
+		else
+			formspec = formspec .. "listring[current_name;craft]"
+		end
 		formspec = formspec.."listring[current_player;main]"
 		if unified_inventory.is_creative(player_name) then
 			formspec = formspec.."label[0,"..(formspecy + 1.5)..";" .. F(S("Refill:")) .. "]"

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -9,3 +9,7 @@ unified_inventory_bags (Enable bags) bool true
 #If enabled, the trash slot can be used by those without both creative
 #and the give privilege.
 unified_inventory_trash (Enable trash) bool true
+
+#If enabled, players in creative mode or with give privilege can
+#delete items by shift-clicking on them.
+unified_inventory_trash_listring (Enable trash listring) bool false


### PR DESCRIPTION
If the player is in creative mode, the listring now directs the items to trash instead of craft grid.

In my opinion this is a convenient feature, so I made a PR.
Note that ~4 years ago, I opened issue #32 for this but VanessaE closed it.