### PR TITLE
Add click tracking for registered pages

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -289,6 +289,9 @@ function unified_inventory.register_page(name, def)
 	unified_inventory.pages[name] = def
 end
 
+function unified_inventory.register_click_tracking(name)
+	unified_inventory.page_click_tracking[name] = true
+end
 
 function unified_inventory.register_button(name, def)
 	if not def.action then

--- a/callbacks.lua
+++ b/callbacks.lua
@@ -144,6 +144,9 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 			unified_inventory.current_item[player_name] = clicked_item
 			unified_inventory.alternate[player_name] = 1
 			unified_inventory.set_inventory_formspec(player, "craftguide")
+		elseif unified_inventory.page_click_tracking[page] then
+			unified_inventory.current_item[player_name] = clicked_item
+			unified_inventory.set_inventory_formspec(player, page)
 		elseif player_creative then
 			local inv = player:get_inventory()
 			local stack = ItemStack(clicked_item)

--- a/init.lua
+++ b/init.lua
@@ -24,6 +24,7 @@ unified_inventory = {
 	filtered_items_list_size = {},
 	filtered_items_list = {},
 	pages = {},
+	page_click_tracking = {},
 	buttons = {},
 
 	-- Homepos stuff


### PR DESCRIPTION
Add the ability for mods to register pages for click tracking in the same format as crafting. This expands the functionality of additional pages to detect what item was chosen in the creative inventory. 