### PR TITLE
Added prepend elements to fix some of the weird artefacts introduced …

### DIFF
--- a/bags.lua
+++ b/bags.lua
@@ -9,7 +9,7 @@ local F = minetest.formspec_escape
 unified_inventory.register_page("bags", {
 	get_formspec = function(player)
 		local player_name = player:get_player_name()
-		local formspec = "background[0.06,0.99;7.92,7.52;ui_bags_main_form.png]"
+		local formspec = "no_prepend[]background[0.06,0.99;7.92,7.52;ui_bags_main_form.png]"
 		formspec = formspec.."label[0,0;"..F(S("Bags")).."]"
 		formspec = formspec.."button[0,2;2,0.5;bag1;"..F(S("Bag @1", 1)).."]"
 		formspec = formspec.."button[2,2;2,0.5;bag2;"..F(S("Bag @1", 2)).."]"
@@ -44,7 +44,7 @@ for i = 1, 4 do
 		get_formspec = function(player)
 			local stack = get_player_bag_stack(player, bi)
 			local image = stack:get_definition().inventory_image
-			local formspec = ("image[7,0;1,1;"..image.."]"
+			local formspec = ("no_prepend[]image[7,0;1,1;"..image.."]"
 					.."label[0,0;"..F(S("Bag @1", bi)).."]"
 					.."listcolors[#00000000;#00000000]"
 					.."list[current_player;bag"..bi.."contents;0,1;8,3;]"

--- a/internal.lua
+++ b/internal.lua
@@ -59,13 +59,13 @@ function unified_inventory.get_formspec(player, page)
 	local pagedef = unified_inventory.pages[page]
 
 	local formspec = {
-		"size[14,10]",
+		"size[14,10]no_prepend[]",
 		"background[-0.19,-0.25;14.4,10.75;ui_form_bg.png]" -- Background
 	}
 	local n = 3
 
 	if draw_lite_mode then
-		formspec[1] = "size[11,7.7]"
+		formspec[1] = "size[11,7.7]no_prepend[]"
 		formspec[2] = "background[-0.19,-0.2;11.4,8.4;ui_form_bg.png]"
 	end
 


### PR DESCRIPTION
…by MT 5.0.0 theming https://forum.minetest.net/viewtopic.php?f=18&t=20646

Since the introduction of theming in MT 5.0.0 there seem to be some artifacts caused by the theming e.g.:

![ui_2](https://user-images.githubusercontent.com/17067614/55282256-ea929c80-5340-11e9-94ff-5bdafe1e4776.png)

By adding no_prepend near the start of the formspec, the cosmetic issue is resolved for the time being e.g. until theming support is added to unified inv

As I am not that familiar with the code, I hope I have covered all the places where it needs to be added and have not added them where not needed. E.g. not sure if they need to be added in bags.lua or not ... Thanks! Beerholder