### PR TITLE
use sethome functions from default game and remove sethome internals from unified_inv

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -154,43 +154,6 @@ minetest.after(0.01, function()
 end)
 
 
--- load_home
-local function load_home()
-	local input = io.open(unified_inventory.home_filename, "r")
-	if not input then
-		unified_inventory.home_pos = {}
-		return
-	end
-	while true do
-		local x = input:read("*n")
-		if not x then break end
-		local y = input:read("*n")
-		local z = input:read("*n")
-		local name = input:read("*l")
-		unified_inventory.home_pos[name:sub(2)] = {x = x, y = y, z = z}
-	end
-	io.close(input)
-end
-load_home()
-
-function unified_inventory.set_home(player, pos)
-	local player_name = player:get_player_name()
-	unified_inventory.home_pos[player_name] = vector.round(pos)
-	-- save the home data from the table to the file
-	local output = io.open(unified_inventory.home_filename, "w")
-	for k, v in pairs(unified_inventory.home_pos) do
-		output:write(v.x.." "..v.y.." "..v.z.." "..k.."\n")
-	end
-	io.close(output)
-end
-
-function unified_inventory.go_home(player)
-	local pos = unified_inventory.home_pos[player:get_player_name()]
-	if pos then
-		player:setpos(pos)
-	end
-end
-
 -- register_craft
 function unified_inventory.register_craft(options)
 	if not options.output then

--- a/depends.txt
+++ b/depends.txt
@@ -1,4 +1,5 @@
 default
+sethome
 creative?
 sfinv?
 intllib?

--- a/init.lua
+++ b/init.lua
@@ -26,10 +26,6 @@ unified_inventory = {
 	pages = {},
 	buttons = {},
 
-	-- Homepos stuff
-	home_pos = {},
-	home_filename =	worldpath.."/unified_inventory_home.home",
-
 	-- Default inventory page
 	default = "craft",
 

--- a/register.lua
+++ b/register.lua
@@ -48,9 +48,12 @@ unified_inventory.register_button("home_gui_set", {
 	action = function(player)
 		local player_name = player:get_player_name()
 		if minetest.check_player_privs(player_name, {home=true}) then
-			unified_inventory.set_home(player, player:getpos())
-			local home = unified_inventory.home_pos[player_name]
-			if home ~= nil then
+			local home = player:get_pos()
+
+			-- use mtg sethome mod function
+			local success = sethome.set(player_name, home)
+
+			if success then
 				minetest.sound_play("dingdong",
 						{to_player=player_name, gain = 1.0})
 				minetest.chat_send_player(player_name,
@@ -77,7 +80,9 @@ unified_inventory.register_button("home_gui_go", {
 		if minetest.check_player_privs(player_name, {home=true}) then
 			minetest.sound_play("teleport",
 				{to_player=player:get_player_name(), gain = 1.0})
-			unified_inventory.go_home(player)
+
+			-- use mtg sethome mod function
+			sethome.go(player_name)
 		else
 			minetest.chat_send_player(player_name,
 				S("You don't have the \"home\" privilege!"))


### PR DESCRIPTION
* fixes #129
* depends now on `sethome`
* no home-tracking in the mod anymore
* uses `sethome.go()` and `sethome.set()` from the minetest-game sethome mod

There was a hard-dep on `default` anyway, so depending on `sethome` won't make it worse...