### PR TITLE
Implement new crafting algorithm

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -305,4 +305,3 @@ function unified_inventory.is_creative(playername)
 	return minetest.check_player_privs(playername, {creative=true})
 		or minetest.settings:get_bool("creative_mode")
 end
-

--- a/init.lua
+++ b/init.lua
@@ -71,6 +71,7 @@ dofile(modpath.."/group.lua")
 dofile(modpath.."/api.lua")
 dofile(modpath.."/internal.lua")
 dofile(modpath.."/callbacks.lua")
+dofile(modpath.."/match_craft.lua")
 dofile(modpath.."/register.lua")
 
 if minetest.settings:get_bool("unified_inventory_bags") ~= false then

--- a/match_craft.lua
+++ b/match_craft.lua
@@ -328,66 +328,65 @@ Arguments:
 	amount: amount of items per every position
 --]]
 function unified_inventory.move_match(player, src_list, dst_list, match_table, amount)
-	local src_dst_list = {src_list, dst_list}
-	local dst_src_list = {dst_list, src_list}
 	local inv = player:get_inventory()
 	local item_drop = minetest.item_drop
-	local moved_positions = {}
+	local src_dst_list = {src_list, dst_list}
+
+	local needed = {}
+	local remained = {}
+	local moved = {}
 
 	for item, pos_set in pairs(match_table) do
-		local needed = {}
-		local remained = {}
-
 		local stack = ItemStack(item)
 		local stack_max = stack:get_stack_max()
 		local bounded_amount = math.min(stack_max, amount)
 
-		-- Pass 1: Remove stacks needed for craft
+		-- Remove stacks needed for craft
 		stack:set_count(bounded_amount)
 
 		for pos in pairs(pos_set) do
-			needed[pos] = unified_inventory.remove_item(inv, dst_src_list, stack)
+			needed[pos] = unified_inventory.remove_item(inv, src_dst_list, stack)
 		end
 
-		-- Pass 2: Remove remainder to free up positions
+		-- Remove remainder to free up positions
 		stack:set_count(stack_max)
 
 		for pos in pairs(pos_set) do
-			remained[pos] = inv:remove_item(dst_list, stack)
-		end
-
-		-- Pass 3: Move only needed stacks
-		for pos, current in pairs(needed) do
-			local occupied = inv:get_stack(dst_list, pos)
-			inv:set_stack(dst_list, pos, current)
-
-			if not occupied:is_empty() then
-				local leftover = unified_inventory.add_item(inv, src_dst_list, occupied)
-
-				if not leftover:is_empty() then
-					inv:set_stack(dst_list, pos, leftover)
-					local oversize = unified_inventory.add_item(inv, src_dst_list, current)
-
-					if not oversize:is_empty() then
-						item_drop(oversize, player, player:get_pos())
-					end
-				end
-			end
-
-			moved_positions[pos] = true
-		end
-
-		-- Pass 4: Re-add remainder stacks
-		for _, current in pairs(remained) do
-			local oversize = unified_inventory.add_item(inv, src_dst_list, current)
-
-			if not oversize:is_empty() then
-				item_drop(oversize, player, player:get_pos())
-			end
+			remained[pos] = unified_inventory.remove_item(inv, src_dst_list, stack)
 		end
 	end
 
-	unified_inventory.swap_items(inv, dst_list, src_list, moved_positions)
+	-- Move only needed stacks
+	for pos, stack in pairs(needed) do
+		local occupied = inv:get_stack(dst_list, pos)
+		inv:set_stack(dst_list, pos, stack)
+
+		if not occupied:is_empty() then
+			local leftover = unified_inventory.add_item(inv, src_dst_list, occupied)
+
+			if not leftover:is_empty() then
+				inv:set_stack(dst_list, pos, leftover)
+				local oversize = unified_inventory.add_item(inv, src_dst_list, stack)
+
+				if not oversize:is_empty() then
+					item_drop(oversize, player, player:get_pos())
+				end
+			end
+		end
+
+		moved[pos] = true
+	end
+
+	unified_inventory.swap_items(inv, dst_list, src_list, moved)
+
+	-- Re-add remainder stacks
+	for _, stack in pairs(remained) do
+		local oversize = unified_inventory.add_item(inv, src_dst_list, stack)
+
+		if not oversize:is_empty() then
+			item_drop(oversize, player, player:get_pos())
+		end
+	end
 end
 
 --[[

--- a/match_craft.lua
+++ b/match_craft.lua
@@ -213,6 +213,11 @@ function unified_inventory.match_items(m, craft_index, item_index)
 		local times_used = #item.craft_positions
 		local cell_count = math.floor(index.total_count / times_used)
 
+		if cell_count == 0 then
+			m.count = 0
+			return
+		end
+
 		index.times_matched = times_used
 		m.count = math.min(m.count, cell_count)
 
@@ -241,6 +246,11 @@ function unified_inventory.match_groups(m, craft_index, item_index)
 				end
 			end
 
+			if cell_count == 0 then
+				m.count = 0
+				return
+			end
+
 			m.count = math.min(m.count, cell_count)
 			m.items[craft_pos] = matched_item.name
 
@@ -260,6 +270,10 @@ function unified_inventory.get_match_table(craft_index, item_index)
 
 	unified_inventory.match_items(match_table, craft_index, item_index)
 	unified_inventory.match_groups(match_table, craft_index, item_index)
+
+	if match_table.count == 0 then
+		return
+	end
 
 	return match_table
 end

--- a/match_craft.lua
+++ b/match_craft.lua
@@ -66,18 +66,21 @@ Example output:
 --]]
 function unified_inventory.count_craft_positions(craft)
 	local positions = {}
-	local items = craft.items
-	local width = craft.width
+	local craft_items = craft.items
+	local craft_type = unified_inventory.registered_craft_types[craft.type]
+	                   or unified_inventory.craft_type_defaults(craft.type, {})
+	local display_width = craft_type.dynamic_display_size
+	                      and craft_type.dynamic_display_size(craft).width
+	                      or craft_type.width
+	local craft_width = craft_type.get_shaped_craft_width
+	                    and craft_type.get_shaped_craft_width(craft)
+	                    or display_width
 	local i = 0
 
-	if width == 0 then
-		width = 3
-	end
-
 	for y = 1, 3 do
-		for x = 1, width do
+		for x = 1, craft_width do
 			i = i + 1
-			local item = items[i]
+			local item = craft_items[i]
 
 			if item ~= nil then
 				local pos = 3 * (y - 1) + x

--- a/match_craft.lua
+++ b/match_craft.lua
@@ -336,9 +336,13 @@ function unified_inventory.move_match(inv, src_lists, dst_list, match_table, amo
 			pos_count = pos_count + 1
 		end
 
+		local total_amount = bounded_amount * pos_count
+		-- round up to the full stack
+		total_amount = math.ceil(total_amount / stack_max) * stack_max
+
 		local total = ItemStack{
 			name = item,
-			count = bounded_amount * pos_count
+			count = total_amount
 		}
 
 		local removed = unified_inventory.remove_item(inv, src_lists, total)

--- a/match_craft.lua
+++ b/match_craft.lua
@@ -1,0 +1,312 @@
+local MAX_COUNT = 99
+
+local function extract_group_name(name)
+	return name:match("^group:(.+)")
+end
+
+local function add_craft_item(t, item_name, craft_pos)
+	local item = t[item_name]
+
+	if item == nil then
+		t[item_name] = {
+			craft_positions = {craft_pos},
+			found = false
+		}
+	else
+		table.insert(item.craft_positions, craft_pos)
+	end
+end
+
+local function add_craft_group(t, group_name, craft_pos)
+	local group = t[group_name]
+
+	if group == nil then
+		t[group_name] = {
+			craft_positions = {craft_pos},
+			found = false,
+			found_items = {}
+		}
+	else
+		table.insert(group.craft_positions, craft_pos)
+	end
+end
+
+local function create_craft_index(craft_items)
+	local craft_index = {
+		items = {},
+		groups = {}
+	}
+
+	for craft_pos, name in pairs(craft_items) do
+		local group_name = extract_group_name(name)
+
+		if group_name == nil then
+			add_craft_item(craft_index.items, name, craft_pos)
+		else
+			add_craft_group(craft_index.groups, group_name, craft_pos)
+		end
+	end
+
+	return craft_index
+end
+
+local function find_craft_item(item_name, craft_index)
+	local found = false
+	local item = craft_index.items[item_name]
+	local get_item_group = minetest.get_item_group
+
+	if item ~= nil then
+		item.found = true
+		found = true
+	end
+
+	for group_name, group in pairs(craft_index.groups) do
+		if get_item_group(item_name, group_name) > 0 then
+			group.found = true
+			found = true
+
+			table.insert(group.found_items, item_name)
+		end
+	end
+
+	return found
+end
+
+local function all_items_found(craft_index)
+	for _, item in pairs(craft_index.items) do
+		if not item.found then
+			return false
+		end
+	end
+
+	for _, group in pairs(craft_index.groups) do
+		if not group.found then
+			return false
+		end
+	end
+
+	return true
+end
+
+local function create_item_index(inv_list, craft_index)
+	local item_index = {}
+	local not_found = {}
+
+	for inv_list_pos, stack in ipairs(inv_list) do
+		local item_name = stack:get_name()
+
+		if item_name ~= "" then
+			local item_count = stack:get_count()
+			local item = item_index[item_name]
+
+			if item == nil then
+				if not_found[item_name] == nil then
+					local item_found = find_craft_item(item_name, craft_index)
+
+					if item_found then
+						item_index[item_name] = {
+							total_count = item_count,
+							times_matched = 0
+						}
+					else
+						not_found[item_name] = true
+					end
+				end
+			else
+				item.total_count = item.total_count + item_count
+			end
+		end
+	end
+
+	return item_index
+end
+
+local function count_compare(item1, item2)
+	return item1.index.total_count > item2.index.total_count
+end
+
+local function lex_compare(group1, group2)
+	local items1 = group1.items
+	local items2 = group2.items
+
+	local len1 = #items1
+	local len2 = #items2
+	local min_len = math.min(len1, len2)
+
+	for i = 1, min_len do
+		local count1 = items1[i].index.total_count
+		local count2 = items2[i].index.total_count
+
+		if count1 ~= count2 then
+			return count1 < count2
+		end
+	end
+
+	return len1 < len2
+end
+
+local function get_group_items(group_name, craft_index, item_index)
+	local items = {}
+	local group = craft_index.groups[group_name]
+
+	for _, item_name in ipairs(group.found_items) do
+		local item = item_index[item_name]
+
+		table.insert(items, {
+			name = item_name,
+			index = item
+		})
+	end
+
+	return items
+end
+
+local function ordered_groups(craft_index, item_index)
+	local groups = {}
+
+	for group_name in pairs(craft_index.groups) do
+		local group_items = get_group_items(group_name, craft_index, item_index)
+		table.sort(group_items, count_compare)
+
+		table.insert(groups, {
+			name = group_name,
+			items = group_items
+		})
+	end
+
+	table.sort(groups, lex_compare)
+
+	local i = 0
+	local n = #groups
+
+	return function()
+		i = i + 1
+
+		if i <= n then
+			local group = groups[i]
+			return craft_index.groups[group.name], group.items
+		end
+	end
+end
+
+local function match_items(m, craft_index, item_index)
+	for item_name, item in pairs(craft_index.items) do
+		local index = item_index[item_name]
+		local times_used = #item.craft_positions
+		local cell_count = math.floor(index.total_count / times_used)
+
+		index.times_matched = times_used
+		m.count = math.min(m.count, cell_count)
+
+		for _, craft_pos in ipairs(item.craft_positions) do
+			m.items[craft_pos] = item_name
+		end
+	end
+end
+
+local function match_groups(m, craft_index, item_index)
+	for group, group_items in ordered_groups(craft_index, item_index) do
+		for _, craft_pos in ipairs(group.craft_positions) do
+			local cell_count = 0
+			local matched_item = nil
+
+			for _, item in ipairs(group_items) do
+				local index = item.index
+
+				local item_count = index.total_count
+				local times_matched = index.times_matched
+				local match_count = math.floor(item_count / (times_matched + 1))
+
+				if match_count > cell_count then
+					cell_count = match_count
+					matched_item = item
+				end
+			end
+
+			m.count = math.min(m.count, cell_count)
+			m.items[craft_pos] = matched_item.name
+
+			local matched_index = matched_item.index
+			matched_index.times_matched = matched_index.times_matched + 1
+		end
+	end
+end
+
+local function get_match_table(craft_index, item_index)
+	local match_table = {
+		count = MAX_COUNT,
+		items = {}
+	}
+
+	match_items(match_table, craft_index, item_index)
+	match_groups(match_table, craft_index, item_index)
+
+	return match_table
+end
+
+local function find_best_match(inv_list, craft_items)
+	local craft_index = create_craft_index(craft_items)
+	local item_index = create_item_index(inv_list, craft_index)
+
+	if not all_items_found(craft_index) then
+		return
+	end
+
+	return get_match_table(craft_index, item_index)
+end
+
+local function can_move(match_items, inv_list)
+	for match_pos, match_name in pairs(match_items) do
+		local inv_item = inv_list[match_pos]
+		local inv_item_name = inv_item:get_name()
+
+		if inv_item_name ~= "" and match_name ~= inv_item_name then
+			return false
+		end
+	end
+
+	return true
+end
+
+function craftguide_match_craft(inv, src_list_name, dst_list_name, craft, amount)
+	local src_list = inv:get_list(src_list_name)
+	local dst_list = inv:get_list(dst_list_name)
+
+	local craft_items = craft.items
+	local craft_match = find_best_match(src_list, craft_items)
+
+	if craft_match == nil then
+		return
+	end
+
+	local matched_items = craft_match.items
+	local matched_count = craft_match.count
+
+	if not can_move(matched_items, dst_list) then
+		return
+	end
+
+	if amount == -1 then
+		amount = matched_count
+	elseif amount > matched_count then
+		return
+	end
+
+	for match_pos, item_name in pairs(matched_items) do
+		local dst_stack = dst_list[match_pos]
+		local dst_count = dst_stack:get_count()
+
+		local matched_stack = ItemStack(item_name)
+		local take_count = math.min(MAX_COUNT - dst_count, amount)
+		matched_stack:set_count(take_count)
+
+		local removed_stack = inv:remove_item(src_list_name, matched_stack)
+		local removed_count = removed_stack:get_count()
+		local sum_count = dst_count + removed_count
+		matched_stack:set_count(sum_count)
+
+		dst_list[match_pos] = matched_stack
+	end
+
+	inv:set_list(dst_list_name, dst_list)
+end

--- a/match_craft.lua
+++ b/match_craft.lua
@@ -325,7 +325,7 @@ Arguments:
 	amount: amount of items per every position
 --]]
 function unified_inventory.move_match(inv, src_lists, dst_list, match_table, amount)
-	local positions = {}
+	local moved_positions = {}
 
 	for item, pos_set in pairs(match_table) do
 		local stack_max = ItemStack(item):get_stack_max()
@@ -346,8 +346,6 @@ function unified_inventory.move_match(inv, src_lists, dst_list, match_table, amo
 		current:set_count(bounded_amount)
 
 		for pos in pairs(pos_set) do
-			positions[pos] = true
-
 			local occupied = inv:get_stack(dst_list, pos)
 			inv:set_stack(dst_list, pos, current)
 
@@ -361,12 +359,13 @@ function unified_inventory.move_match(inv, src_lists, dst_list, match_table, amo
 			end
 
 			removed:take_item(bounded_amount)
+			moved_positions[pos] = true
 		end
 
 		unified_inventory.add_item(inv, src_lists, removed)
 	end
 
-	unified_inventory.swap_items(inv, dst_list, src_lists, positions)
+	unified_inventory.swap_items(inv, dst_list, src_lists, moved_positions)
 end
 
 --[[

--- a/match_craft.lua
+++ b/match_craft.lua
@@ -336,13 +336,9 @@ function unified_inventory.move_match(inv, src_lists, dst_list, match_table, amo
 			pos_count = pos_count + 1
 		end
 
-		local total_amount = bounded_amount * pos_count
-		-- round up to the full stack
-		total_amount = math.ceil(total_amount / stack_max) * stack_max
-
 		local total = ItemStack{
 			name = item,
-			count = total_amount
+			count = bounded_amount * pos_count
 		}
 
 		local removed = unified_inventory.remove_item(inv, src_lists, total)

--- a/match_craft.lua
+++ b/match_craft.lua
@@ -349,16 +349,19 @@ function unified_inventory.move_match(inv, src_lists, dst_list, match_table, amo
 			local occupied = inv:get_stack(dst_list, pos)
 			inv:set_stack(dst_list, pos, current)
 
-			if not occupied:is_empty() then
-				local leftover = unified_inventory.add_item(inv, src_lists, occupied)
+			repeat
+				if not occupied:is_empty() then
+					local leftover = unified_inventory.add_item(inv, src_lists, occupied)
 
-				if not leftover:is_empty() then
-					inv:set_stack(dst_list, pos, leftover)
-					break
+					if not leftover:is_empty() then
+						inv:set_stack(dst_list, pos, leftover)
+						break
+					end
 				end
-			end
 
-			removed:take_item(bounded_amount)
+				removed:take_item(bounded_amount)
+			until true
+
 			moved_positions[pos] = true
 		end
 

--- a/match_craft.lua
+++ b/match_craft.lua
@@ -163,6 +163,21 @@ function unified_inventory.create_item_index(inv_list, craft_index)
 	return item_index
 end
 
+function unified_inventory.get_total_stack_max(item_index)
+	local total_max = nil
+
+	for item_name in pairs(item_index) do
+		local stack = ItemStack(item_name)
+		local stack_max = stack:get_stack_max()
+
+		if total_max == nil or stack_max < total_max then
+			total_max = stack_max
+		end
+	end
+
+	return total_max
+end
+
 function unified_inventory.get_group_items(group_name, craft_index, item_index)
 	local items = {}
 	local group = craft_index.groups[group_name]
@@ -261,10 +276,8 @@ function unified_inventory.match_groups(m, craft_index, item_index)
 end
 
 function unified_inventory.get_match_table(craft_index, item_index)
-	local MAX_COUNT = 99
-
 	local match_table = {
-		count = MAX_COUNT,
+		count = unified_inventory.get_total_stack_max(item_index),
 		items = {}
 	}
 
@@ -333,9 +346,7 @@ function unified_inventory.craftguide_match_craft(inv, src_list_name, dst_list_n
 		local dst_count = dst_stack:get_count()
 
 		local matched_stack = ItemStack(item_name)
-		local match_max = matched_stack:get_stack_max()
-
-		local take_count = math.min(match_max - dst_count, amount)
+		local take_count = amount - dst_count
 
 		if take_count > 0 then
 			matched_stack:set_count(take_count)

--- a/match_craft.lua
+++ b/match_craft.lua
@@ -31,19 +31,40 @@ local function add_craft_group(t, group_name, craft_pos)
 	end
 end
 
-local function create_craft_index(craft_items)
+local function create_craft_index(craft)
 	local craft_index = {
 		items = {},
 		groups = {}
 	}
 
-	for craft_pos, name in pairs(craft_items) do
-		local group_name = extract_group_name(name)
+	local MAX_HEIGHT = 3
+	local MAX_WIDTH = 3
 
-		if group_name == nil then
-			add_craft_item(craft_index.items, name, craft_pos)
-		else
-			add_craft_group(craft_index.groups, group_name, craft_pos)
+	local craft_items = craft.items
+	local craft_width = craft.width
+
+	if craft_width == 0 then
+		craft_width = MAX_WIDTH
+	end
+
+	local pos = 1
+
+	for y = 1, MAX_HEIGHT do
+		for x = 1, craft_width do
+			local craft_pos = (y - 1) * MAX_WIDTH + x
+			local item = craft_items[pos]
+
+			if item ~= nil then
+				local group = extract_group_name(item)
+
+				if group == nil then
+					add_craft_item(craft_index.items, item, craft_pos)
+				else
+					add_craft_group(craft_index.groups, group, craft_pos)
+				end
+			end
+
+			pos = pos + 1
 		end
 	end
 
@@ -244,8 +265,8 @@ local function get_match_table(craft_index, item_index)
 	return match_table
 end
 
-local function find_best_match(inv_list, craft_items)
-	local craft_index = create_craft_index(craft_items)
+local function find_best_match(inv_list, craft)
+	local craft_index = create_craft_index(craft)
 	local item_index = create_item_index(inv_list, craft_index)
 
 	if not all_items_found(craft_index) then
@@ -272,8 +293,7 @@ function craftguide_match_craft(inv, src_list_name, dst_list_name, craft, amount
 	local src_list = inv:get_list(src_list_name)
 	local dst_list = inv:get_list(dst_list_name)
 
-	local craft_items = craft.items
-	local craft_match = find_best_match(src_list, craft_items)
+	local craft_match = find_best_match(src_list, craft)
 
 	if craft_match == nil then
 		return

--- a/match_craft.lua
+++ b/match_craft.lua
@@ -298,7 +298,11 @@ function unified_inventory.swap_items(inv, src_list, dst_lists, exclude)
 
 			if not stack:is_empty() then
 				inv:set_stack(src_list, i, empty)
-				unified_inventory.add_item(inv, dst_lists, stack)
+				local leftover = unified_inventory.add_item(inv, dst_lists, stack)
+
+				if not leftover:is_empty() then
+					inv:set_stack(src_list, i, leftover)
+				end
 			end
 		end
 	end

--- a/match_craft.lua
+++ b/match_craft.lua
@@ -289,7 +289,7 @@ local function can_move(match_items, inv_list)
 	return true
 end
 
-function craftguide_match_craft(inv, src_list_name, dst_list_name, craft, amount)
+function unified_inventory.craftguide_match_craft(inv, src_list_name, dst_list_name, craft, amount)
 	local src_list = inv:get_list(src_list_name)
 	local dst_list = inv:get_list(dst_list_name)
 

--- a/register.lua
+++ b/register.lua
@@ -467,7 +467,7 @@ local function craftguide_craft(player, formname, fields)
 	local craft = crafts[alternate]
 	if craft.width > 3 then return end
 
-	craftguide_match_craft(player_inv, "main", "craft", craft, amount)
+	unified_inventory.craftguide_match_craft(player_inv, "main", "craft", craft, amount)
 
 	unified_inventory.set_inventory_formspec(player, "craft")
 end

--- a/register.lua
+++ b/register.lua
@@ -465,7 +465,7 @@ local function craftguide_craft(player, formname, fields)
 	local craft = crafts[alternate]
 	if craft.width > 3 then return end
 
-	unified_inventory.craftguide_match_craft(player, {"main", "craft"}, "craft", craft, amount)
+	unified_inventory.craftguide_match_craft(player, "main", "craft", craft, amount)
 
 	unified_inventory.set_inventory_formspec(player, "craft")
 end

--- a/register.lua
+++ b/register.lua
@@ -456,8 +456,6 @@ local function craftguide_craft(player, formname, fields)
 	local output = unified_inventory.current_item[player_name] or ""
 	if output == "" then return end
 
-	local player_inv = player:get_inventory()
-
 	local crafts = unified_inventory.crafts_for[
 		unified_inventory.current_craft_direction[player_name]][output] or {}
 	if #crafts == 0 then return end
@@ -467,7 +465,7 @@ local function craftguide_craft(player, formname, fields)
 	local craft = crafts[alternate]
 	if craft.width > 3 then return end
 
-	unified_inventory.craftguide_match_craft(player_inv, {"main", "craft"}, "craft", craft, amount)
+	unified_inventory.craftguide_match_craft(player, {"main", "craft"}, "craft", craft, amount)
 
 	unified_inventory.set_inventory_formspec(player, "craft")
 end

--- a/register.lua
+++ b/register.lua
@@ -440,65 +440,6 @@ local function craftguide_giveme(player, formname, fields)
 	player_inv:add_item("main", {name = output, count = amount})
 end
 
--- Takes any stack from "main" where the `amount` of `needed_item` may fit
--- into the given crafting stack (`craft_item`)
-local function craftguide_move_stacks(inv, craft_item, needed_item, amount)
-	if craft_item:get_count() >= amount then
-		return
-	end
-
-	local get_item_group = minetest.get_item_group
-	local group = needed_item:match("^group:(.+)")
-	if group then
-		if not craft_item:is_empty() then
-			-- Source item must be the same to fill
-			if get_item_group(craft_item:get_name(), group) ~= 0 then
-				needed_item = craft_item:get_name()
-			else
-				-- TODO: Maybe swap unmatching "craft" items
-				-- !! Would conflict with recursive function call
-				return
-			end
-		else
-			-- Take matching group from the inventory (biggest stack)
-			local main = inv:get_list("main")
-			local max_found = 0
-			for i, stack in ipairs(main) do
-				if stack:get_count() > max_found and
-						get_item_group(stack:get_name(), group) ~= 0 then
-					needed_item = stack:get_name()
-					max_found = stack:get_count()
-					if max_found >= amount then
-						break
-					end
-				end
-			end
-		end
-	else
-		if not craft_item:is_empty() and
-				craft_item:get_name() ~= needed_item then
-			return -- Item must be identical
-		end
-	end
-
-	needed_item = ItemStack(needed_item)
-	local to_take = math.min(amount, needed_item:get_stack_max())
-	to_take = to_take - craft_item:get_count()
-	if to_take <= 0 then
-		return -- Nothing to do
-	end
-	needed_item:set_count(to_take)
-
-	local taken = inv:remove_item("main", needed_item)
-	local leftover = taken:add_item(craft_item)
-	if not leftover:is_empty() then
-		-- Somehow failed to add the existing "craft" item. Undo the action.
-		inv:add_item("main", leftover)
-		return taken
-	end
-	return taken
-end
-
 local function craftguide_craft(player, formname, fields)
 	local amount
 	for k, v in pairs(fields) do
@@ -507,8 +448,8 @@ local function craftguide_craft(player, formname, fields)
 	end
 	if not amount then return end
 
-	amount = tonumber(amount) or 99 -- fallback for "all"
-	if amount <= 0 or amount > 99 then return end
+	amount = tonumber(amount) or -1 -- fallback for "all"
+	if amount == 0 or amount < -1 or amount > 99 then return end
 
 	local player_name = player:get_player_name()
 
@@ -516,7 +457,6 @@ local function craftguide_craft(player, formname, fields)
 	if output == "" then return end
 
 	local player_inv = player:get_inventory()
-	local craft_list = player_inv:get_list("craft")
 
 	local crafts = unified_inventory.crafts_for[
 		unified_inventory.current_craft_direction[player_name]][output] or {}
@@ -527,38 +467,7 @@ local function craftguide_craft(player, formname, fields)
 	local craft = crafts[alternate]
 	if craft.width > 3 then return end
 
-	local needed = craft.items
-	local width = craft.width
-	if width == 0 then
-		-- Shapeless recipe
-		width = 3
-	end
-
-	-- To spread the items evenly
-	local STEPSIZE = math.ceil(math.sqrt(amount) / 5) * 5
-	local current_count = 0
-	repeat
-		current_count = math.min(current_count + STEPSIZE, amount)
-		local index = 1
-		for y = 1, 3 do
-			for x = 1, width do
-				local needed_item = needed[index]
-				if needed_item then
-					local craft_index = ((y - 1) * 3) + x
-					local craft_item = craft_list[craft_index]
-					local newitem = craftguide_move_stacks(player_inv,
-							craft_item, needed_item, current_count)
-
-					if newitem then
-						craft_list[craft_index] = newitem
-					end
-				end
-				index = index + 1
-			end
-		end
-	until current_count == amount
-
-	player_inv:set_list("craft", craft_list)
+	craftguide_match_craft(player_inv, "main", "craft", craft, amount)
 
 	unified_inventory.set_inventory_formspec(player, "craft")
 end

--- a/register.lua
+++ b/register.lua
@@ -467,7 +467,7 @@ local function craftguide_craft(player, formname, fields)
 	local craft = crafts[alternate]
 	if craft.width > 3 then return end
 
-	unified_inventory.craftguide_match_craft(player_inv, "main", "craft", craft, amount)
+	unified_inventory.craftguide_match_craft(player_inv, {"main", "craft"}, "craft", craft, amount)
 
 	unified_inventory.set_inventory_formspec(player, "craft")
 end


### PR DESCRIPTION
I wrote a better version of crafting algorithm that, I believe, *optimally* matches inventory items to crafting grid.

The algorithm can be briefly described in the following steps:
- Get info about crafting items and groups, their positions in the crafting recipe (`craft_index`)
- Get info about inventory items that can be used in the craft, their total count in inventory (`item_index`)
- Match craft items and groups with inventory items according to the recipe and also find the amount of items for every recipe cell:
    - Item matching is easy because its always 1:1 match
    - Optimal group matching requires the specific order of iteration through groups (their items counts). For that, every group items counts are first sorted in descending order and then compared "lexicographically".
After that, we iterate through sorted groups (their items counts) and for every group we take item with max possible `total_count / (times_matched + 1)` value.
Global amount of items per cell is the min of this values.
- Check if crafting grid already contains only needed items (or empty cells) and move stacks from main inventory.

As to why the order of group iteration is important, consider an example:

|                        | Inv Item 1 (count = 28)  | Inv Item 2 (count = 15) | Inv Item 3 (count = 20)
|------------------ | ----------------------------- | ------------------------------ | -----------------------------|
| Group Cell 1 | ✓                                    | ✓                                    |                                      |
| Group Cell 2 | ✓                                    |                                        | ✓                                  |

If we start with group 2, we first match item 1 for group 2 (`28 / (0 + 1) = 28`) then item 2 for group 1 (because `[28 / (1 + 1)] < [15 / (0 + 1)]`), and the best amount we can get is 15. But actually 20 is the best (group 1 - item 1, group 2 - item 3).

The really hard case is when crafting grid is not empty. In that case the algorithm still find match for every recipe cell and moves matched items only if the craft grid already have the same items in the same positions (or empty). Actually, I don't like this behavior on non-empty grid, but there are too many cases to consider to make the algorithm work correctly (so it can, for example, ignore some cells if the crafting grid already have large amount of items in them), especially when there are groups of items in the craft recipe. Also it would require an extra re-matching step.

I believe that the algorithm works correctly with any crafting recipe whether it contains groups or not, but if you've found some bug or mistake please tell about it. I hope that this PR helps!