### PR TITLE
Added the meta data field "creator" for items created in creative mode

### DIFF
--- a/callbacks.lua
+++ b/callbacks.lua
@@ -152,6 +152,8 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 			local inv = player:get_inventory()
 			local stack = ItemStack(clicked_item)
 			stack:set_count(stack:get_stack_max())
+			local meta = stack:get_meta()
+			meta:set_string("creator", player_name)
 			if inv:room_for_item("main", stack) then
 				inv:add_item("main", stack)
 			end

--- a/register.lua
+++ b/register.lua
@@ -441,7 +441,7 @@ local function craftguide_giveme(player, formname, fields)
 	local itemstack = ItemStack({name = output, count = amount})
 	local meta = itemstack:get_meta()
 	meta:set_string("creator", player_name)
-	
+
 	player_inv:add_item("main", itemstack)
 end
 

--- a/register.lua
+++ b/register.lua
@@ -438,7 +438,11 @@ local function craftguide_giveme(player, formname, fields)
 
 	local player_inv = player:get_inventory()
 
-	player_inv:add_item("main", {name = output, count = amount})
+	local itemstack = ItemStack({name = output, count = amount})
+	local meta = itemstack:get_meta()
+	meta:set_string("creator", player_name)
+	
+	player_inv:add_item("main", itemstack)
 end
 
 local function craftguide_craft(player, formname, fields)


### PR DESCRIPTION
This can be used by other mods to verify the origin of items. It becomes handy on event servers, if players get temporary creative mode, but are not allowed to keep any items.