### PR TITLE
LuaCheck: Add `hb` as a global

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -12,6 +12,8 @@ read_globals = {
 
 	"minetest", "vector",
 	"ItemStack", "datastorage",
+
+	"hb",
 }
 
 files["callbacks.lua"].ignore = { "player", "draw_lite_mode" }


### PR DESCRIPTION
Fixes build status warning.
`hb` global is from [HUD bars](https://forum.minetest.net/viewtopic.php?f=11&t=11153) by Wuzzy2.

Build status indicates it's failing because `.luacheckrc` is outdated on this repository.
Build will pass when this PR gets merged.
