### PR TITLE
Formspec Theming

### DIFF
--- a/bags.lua
+++ b/bags.lua
@@ -12,7 +12,6 @@ unified_inventory.register_page("bags", {
 	get_formspec = function(player)
 		local player_name = player:get_player_name()
 		return { formspec = table.concat({
-			"background[0.06,0.99;7.92,7.52;ui_bags_main_form.png]",
 			"label[0,0;" .. F(S("Bags")) .. "]",
 			"button[0,2;2,0.5;bag1;" .. F(S("Bag @1", 1)) .. "]",
 			"button[2,2;2,0.5;bag2;" .. F(S("Bag @1", 2)) .. "]",
@@ -49,19 +48,10 @@ for bag_i = 1, 4 do
 			local fs = {
 				"image[7,0;1,1;" .. image .. "]",
 				"label[0,0;" .. F(S("Bag @1", bag_i)) .. "]",
-				"listcolors[#00000000;#00000000]",
 				"list[current_player;bag" .. bag_i .. "contents;0,1;8,3;]",
 				"listring[current_name;bag" .. bag_i .. "contents]",
 				"listring[current_player;main]"
 			}
-			local slots = stack:get_definition().groups.bagslots
-			if slots == 8 then
-					fs[#fs + 1] = "background[0.06,0.99;7.92,7.52;ui_bags_sm_form.png]"
-			elseif slots == 16 then
-					fs[#fs + 1] = "background[0.06,0.99;7.92,7.52;ui_bags_med_form.png]"
-			elseif slots == 24 then
-					fs[#fs + 1] = "background[0.06,0.99;7.92,7.52;ui_bags_lg_form.png]"
-			end
 			local player_name = player:get_player_name() -- For if statement.
 			if unified_inventory.trash_enabled
 					or unified_inventory.is_creative(player_name)

--- a/doc/mod_api.txt
+++ b/doc/mod_api.txt
@@ -28,7 +28,7 @@ Register a new page: The callback inside this function is called on user input.
 				-- ^ Optional. Hides the player's `main` inventory list
 				draw_item_list = false,   -- default `true`
 				-- ^ Optional. Hides the item list on the right side
-				formspec_prepend = false, -- default `false`
+				formspec_prepend = false, -- default `true`
 				-- ^ Optional. When `false`: Disables the formspec prepend
 			}
 		end,

--- a/internal.lua
+++ b/internal.lua
@@ -62,16 +62,16 @@ function unified_inventory.get_formspec(player, page)
 		return "" -- Invalid page name
 	end
 
-	local formspec = {
-		"size[14,10]",
-		pagedef.formspec_prepend and "" or "no_prepend[]",
-		"background[-0.19,-0.25;14.4,10.75;ui_form_bg.png]" -- Background
-	}
-	local n = 4
+	local formspec = {"size[14,10]"}
+	if pagedef.formspec_prepend or pagedef.formspec_prepend == nil then
+		formspec[2] = ""
+	else
+		formspec[2] = "no_prepend[]"
+	end
+	local n = 3
 
 	if draw_lite_mode then
 		formspec[1] = "size[11,7.7]"
-		formspec[3] = "background[-0.19,-0.2;11.4,8.4;ui_form_bg.png]"
 	end
 
 	if unified_inventory.is_creative(player_name)

--- a/internal.lua
+++ b/internal.lua
@@ -79,6 +79,14 @@ function unified_inventory.get_formspec(player, page)
 
 	formspec[n] = fsdata.formspec
 	n = n+1
+	
+	-- Hack to make UI consistent until mods transition away from backgrounds
+	if minetest.features.formspec_version_element then
+		formspec[n] = "background9[5,5;1,1;gui_formbg.png;true;10]"
+	else
+		formspec[n] = "background[5,5;1,1;gui_formbg.png;true]"
+	end
+	n = n+1
 
 	local button_row = 0
 	local button_col = 0

--- a/internal.lua
+++ b/internal.lua
@@ -123,9 +123,8 @@ function unified_inventory.get_formspec(player, page)
 
 	if fsdata.draw_inventory ~= false then
 		-- Player inventory
-		formspec[n] = "listcolors[#00000000;#00000000]"
-		formspec[n+1] = "list[current_player;main;0,"..(ui_peruser.formspec_y + 3.5)..";8,4;]"
-		n = n+2
+		formspec[n] = "list[current_player;main;0,"..(ui_peruser.formspec_y + 3.5)..";8,4;]"
+		n = n+1
 	end
 
 	if fsdata.draw_item_list == false then

--- a/internal.lua
+++ b/internal.lua
@@ -74,12 +74,6 @@ function unified_inventory.get_formspec(player, page)
 		formspec[1] = "size[11,7.7]"
 	end
 
-	if unified_inventory.is_creative(player_name)
-	and page == "craft" then
-		formspec[n] = "background[0,"..(ui_peruser.formspec_y + 2)..";1,1;ui_single_slot.png]"
-		n = n+1
-	end
-
 	local perplayer_formspec = unified_inventory.get_per_player_formspec(player_name)
 	local fsdata = pagedef.get_formspec(player, perplayer_formspec)
 

--- a/register.lua
+++ b/register.lua
@@ -170,15 +170,12 @@ unified_inventory.register_page("craft", {
 		local formheadery =  perplayer_formspec.form_header_y
 
 		local player_name = player:get_player_name()
-		local formspec = "background[2,"..formspecy..";6,3;ui_crafting_form.png]"
-		formspec = formspec.."background[0,"..(formspecy + 3.5)..";8,4;ui_main_inventory.png]"
+		local formspec = "image[5,"..formspecy..";1,1;gui_furnace_arrow_bg.png^[transformR270]]"
 		formspec = formspec.."label[0,"..formheadery..";" ..F(S("Crafting")).."]"
-		formspec = formspec.."listcolors[#00000000;#00000000]"
 		formspec = formspec.."list[current_player;craftpreview;6,"..formspecy..";1,1;]"
 		formspec = formspec.."list[current_player;craft;2,"..formspecy..";3,3;]"
 		if unified_inventory.trash_enabled or unified_inventory.is_creative(player_name) or minetest.get_player_privs(player_name).give then
 			formspec = formspec.."label[7,"..(formspecy + 1.5)..";" .. F(S("Trash:")) .. "]"
-			formspec = formspec.."background[7,"..(formspecy + 2)..";1,1;ui_single_slot.png]"
 			formspec = formspec.."list[detached:trash;main;7,"..(formspecy + 2)..";1,1;]"
 		end
 		formspec = formspec.."listring[current_name;craft]"
@@ -267,11 +264,7 @@ unified_inventory.register_page("craftguide", {
 
 		local player_name = player:get_player_name()
 		local player_privs = minetest.get_player_privs(player_name)
-		local fs = {
-			"background[0,"..(formspecy + 3.5)..";8,4;ui_main_inventory.png]",
-			"label[0,"..formheadery..";" .. F(S("Crafting Guide")) .. "]",
-			"listcolors[#00000000;#00000000]"
-		}
+		local fs = {"label[0,"..formheadery..";" .. F(S("Crafting Guide")) .. "]"}
 		local item_name = unified_inventory.current_item[player_name]
 		if not item_name then
 			return { formspec = table.concat(fs) }
@@ -298,7 +291,7 @@ unified_inventory.register_page("craftguide", {
 		end
 		local has_give = player_privs.give or unified_inventory.is_creative(player_name)
 
-		fs[#fs + 1] = "background[0.5,"..(formspecy + 0.2)..";8,3;ui_craftguide_form.png]"
+		fs[#fs + 1] = "image[5.6,"..(formspecy + 0.2)..";1,1;gui_furnace_arrow_bg.png^[transformR270]]"
 		fs[#fs + 1] = string.format("textarea[%f,%f;10,1;;%s: %s;]",
 				craftresultx, craftresulty, F(role_text[dir]), item_name_shown)
 		fs[#fs + 1] = stack_image_button(0, formspecy, 1.1, 1.1,

--- a/waypoints.lua
+++ b/waypoints.lua
@@ -23,8 +23,7 @@ unified_inventory.register_page("waypoints", {
 		if not waypoints_temp[player_name] then waypoints_temp[player_name] = {hud = 1} end
 
 		local waypoints = datastorage.get(player_name, "waypoints")
-		local formspec = "background[0,4.5;8,4;ui_main_inventory.png]" ..
-			"image[0,0;1,1;ui_waypoints_icon.png]" ..
+		local formspec = "image[0,0;1,1;ui_waypoints_icon.png]" ..
 			"label[1,0;" .. F(S("Waypoints")) .. "]"
 
 		-- Tabs buttons:


### PR DESCRIPTION
This pull requests addresses changes to transition Unified Inventory away from it's own theme and instead use the default/prepended themes. This allows the inventory formspec to remain consistent with other formspecs provided in the default mod, such as the furnace. It also means less effort is needed when creating or modifying pages because custom background images aren't needed; inventory slots can moved around without modifying images.

Areas that have been addressed:
- Background images removed from the code
- List colors removed
- Use default furnace GUI arrow for pointing to crafting output
- Formspec prepends are allowed by default (to get theming from the default mod), but they can still be disabled if explicitly set to false

Areas of concern:
- Other mods can add their own pages and custom backgrounds. An example is the 3D Armor mod. If this happens, the page looks weird/ugly. A workaround that I implemented is to set the default GUI background after the page formspec code to essentially cover and backgrounds set by mods. The idea would be to keep this in place until we can notify mods using custom backgrounds of the new changes. After most mods transition, we could remove the hack.
- Some mods might use the background images in Unified Inventory instead of creating their own. For that reason, I have not removed any textures from the mod. When the time comes, we could either remove the textures, or change them to 1x1px transparent images that way any mod using them won't have missing textures and it won't interfere with the look of the formspec.

I have attached a few pictures showing what the current formspec looks like. The 3D Armor mod has not been changed in the screenshot. It still has it's own background in it's code. It's the hack mentioned above that covers that up until mods have time to adjust. 
![3D_Armor](https://user-images.githubusercontent.com/29903689/102297827-dbee7d80-3f47-11eb-97c5-365d5884cc29.png)
![Craft_Guide_Page](https://user-images.githubusercontent.com/29903689/102297829-dc871400-3f47-11eb-8444-f04daef7658e.png)
![Crafting_Page](https://user-images.githubusercontent.com/29903689/102297830-dd1faa80-3f47-11eb-9a22-f03b98631cc5.png)


Any other thoughts?
