### PR TITLE
added optional confirmation dialog before clearing inventory

### DIFF
--- a/clear_inventory.lua
+++ b/clear_inventory.lua
@@ -1,0 +1,66 @@
+local S = minetest.get_translator("unified_inventory")
+local ui = unified_inventory
+
+local function clear_inventory(player)
+	local player_name = player:get_player_name()
+	if not ui.is_creative(player_name) then
+		minetest.chat_send_player(player_name,
+				S("This button has been disabled outside"
+				.." of creative mode to prevent"
+				.." accidental inventory trashing."
+				.."\nUse the trash slot instead."))
+		ui.set_inventory_formspec(player, ui.current_page[player_name])
+		return
+	end
+	player:get_inventory():set_list("main", {})
+	minetest.chat_send_player(player_name, S('Inventory cleared!'))
+	minetest.sound_play("trash_all",
+			{to_player=player_name, gain = 1.0})
+end
+
+local clear_inv_button = {
+	type = "image",
+	image = "ui_trash_icon.png",
+	tooltip = S("Clear inventory"),
+	condition = function(player)
+		return ui.is_creative(player:get_player_name())
+	end,
+}
+
+print("bool :", minetest.settings:get_bool("unified_inventory_clear_inventory_confirm"))
+
+if minetest.settings:get_bool("unified_inventory_clear_inventory_confirm") then
+	ui.register_page("clear_inv", {
+		get_formspec = function(player, perplayer_formspec)
+			return {
+				formspec = perplayer_formspec.standard_inv_bg ..
+				"label[1,1;" .. S("Clear inventory") .. " ?]" ..
+				"image_button[4,2;1.5,1.5;ui_ok_icon.png;clear_inv_confirm;]" ..
+				"image_button[6,2;1.5,1.5;ui_no.png;clear_inv_cancel;]"
+				,
+			}
+		end,
+	})
+
+	minetest.register_on_player_receive_fields(function(player, formname, fields)
+		if formname ~= "" then
+			return
+		end
+
+		for k, v in pairs(fields) do
+			if k:match("clear_inv_confirm") then
+				clear_inventory(player)
+				ui.set_inventory_formspec(player, "craft")
+				return
+			end
+			if k:match("clear_inv_cancel") then
+				ui.set_inventory_formspec(player, "craft")
+				return
+			end
+		end
+	end)
+else
+	clear_inv_button.action = clear_inventory
+end
+
+ui.register_button("clear_inv", clear_inv_button)

--- a/init.lua
+++ b/init.lua
@@ -160,6 +160,7 @@ dofile(modpath.."/internal.lua")
 dofile(modpath.."/callbacks.lua")
 dofile(modpath.."/match_craft.lua")
 dofile(modpath.."/register.lua")
+dofile(modpath.."/clear_inventory.lua")
 
 if minetest.settings:get_bool("unified_inventory_bags") ~= false then
 	dofile(modpath.."/bags.lua")

--- a/register.lua
+++ b/register.lua
@@ -138,31 +138,6 @@ ui.register_button("misc_set_night", {
 	end,
 })
 
-ui.register_button("clear_inv", {
-	type = "image",
-	image = "ui_trash_icon.png",
-	tooltip = S("Clear inventory"),
-	action = function(player)
-		local player_name = player:get_player_name()
-		if not ui.is_creative(player_name) then
-			minetest.chat_send_player(player_name,
-					S("This button has been disabled outside"
-					.." of creative mode to prevent"
-					.." accidental inventory trashing."
-					.."\nUse the trash slot instead."))
-			ui.set_inventory_formspec(player, ui.current_page[player_name])
-			return
-		end
-		player:get_inventory():set_list("main", {})
-		minetest.chat_send_player(player_name, S('Inventory cleared!'))
-		minetest.sound_play("trash_all",
-				{to_player=player_name, gain = 1.0})
-	end,
-	condition = function(player)
-		return ui.is_creative(player:get_player_name())
-	end,
-})
-
 ui.register_page("craft", {
 	get_formspec = function(player, perplayer_formspec)
 

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -10,5 +10,7 @@ unified_inventory_bags (Enable bags) bool true
 #and the give privilege.
 unified_inventory_trash (Enable trash) bool true
 
+#If enabled, a dialog will ask for confirmation before clearing inventory
+unified_inventory_clear_inventory_confirm (Confirmation dialog) bool false
 
 unified_inventory_automatic_categorization (Items automatically added to categories) bool true


### PR DESCRIPTION
<img width="774" alt="Screenshot 2021-04-08 at 12 13 18" src="https://user-images.githubusercontent.com/9484563/114040575-090ec500-9884-11eb-8cb4-f57528173596.png">

- has no effect unless minetest.conf contains `unified_inventory_clear_inventory_confirm = true`
- relevant code moved to new `clear_inventory.lua` file
