### PR TITLE
Allow for sorting of recipe lists by customizable sorting functions

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -133,7 +133,11 @@ minetest.after(0.01, function()
 			end
 		end
 	end
-	for _, recipes in pairs(ui.crafts_for.recipe) do
+	for item_name, recipes in pairs(ui.crafts_for.recipe) do
+		local craft_sorter = ui.craft_sorters[item_name] or ui.craft_sorters._default_
+		if craft_sorter then
+			table.sort(recipes, craft_sorter)
+		end
 		for _, recipe in ipairs(recipes) do
 			local ingredient_items = {}
 			for _, spec in pairs(recipe.items) do
@@ -307,6 +311,15 @@ function ui.register_button(name, def)
 	end
 	def.name = name
 	table.insert(ui.buttons, def)
+end
+
+ui.craft_sorters = {}
+function ui.register_craft_sorter(method, item_name)
+	if type(method) ~= "function" then
+		error(("Craft sorter method must be a function, %s given."):format(type(method)))
+	end
+	if not item_name then item_name = "_default_" end
+	craft_sorters[item_name] = method
 end
 
 function ui.is_creative(playername)


### PR DESCRIPTION
This helps fix https://github.com/BlockySurvival/issue-tracker/issues/92
And is related to a point in https://github.com/BlockySurvival/issue-tracker/issues/341

It's a common issue that the most useful craft is rarely the first one to appear in the list

This is due to some crafts being registered or overridden after the origin mod has loaded

There doesn't seem to be any easy solution, any way the current logic in this mod could be changed to change the order of crafts would inevitably cause some crafts to fall out of the ideal order.

This solution provides an API method to add custom sorting methods, one for each item if required. This will allow server maintainers to organise crafts however they see fit: if they think digging recipes should appear first, they can make it that way; if they think crafts containing any item matching `dye:.*` should be pushed to the end they can do that too, or any indefinitely complex logic they desire.