### PR TITLE
add setting to hide disabled buttons

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -52,6 +52,8 @@ unified_inventory = {
 	list_img_offset = 0.13,
 	standard_background = "bgcolor[#0000]background9[0,0;1,1;ui_formbg_9_sliced.png;true;16]",
 
+	hide_disabled_buttons = minetest.settings:get_bool("unified_inventory_hide_disabled_buttons", false),
+
 	version = 4
 }
 

--- a/internal.lua
+++ b/internal.lua
@@ -53,9 +53,11 @@ local function formspec_tab_buttons(player, formspec, style)
 
 	local filtered_inv_buttons = {}
 
-	for i, def in pairs(ui.buttons) do
+	for _, def in pairs(ui.buttons) do
 		if not (style.is_lite_mode and def.hide_lite) then
-			table.insert(filtered_inv_buttons, def)
+			if (def.condition == nil or def.condition(player) or not hide_disabled_buttons) then
+				table.insert(filtered_inv_buttons, def)
+			end
 		end
 	end
 
@@ -66,28 +68,25 @@ local function formspec_tab_buttons(player, formspec, style)
 		style.main_button_cols * style.btn_spc, style.main_button_rows -- size
 	)
 	n = n + 1
-	local i = 1
 
-	for _, def in pairs(filtered_inv_buttons) do
+	for i, def in pairs(filtered_inv_buttons) do
 		local pos_x =           ((i - 1) % style.main_button_cols) * style.btn_spc
 		local pos_y = math.floor((i - 1) / style.main_button_cols) * style.btn_spc
 
 		if def.type == "image" then
-			if (def.condition == nil or def.condition(player) == true) then
+			if (def.condition == nil or def.condition(player)) then
 				formspec[n] = string.format("image_button[%g,%g;%g,%g;%s;%s;]",
 					pos_x, pos_y, style.btn_size, style.btn_size,
 					F(def.image),
 					F(def.name))
 				formspec[n+1] = "tooltip["..F(def.name)..";"..(def.tooltip or "").."]"
 				n = n+2
-				i = i + 1
 
-			elseif not hide_disabled_buttons then
+			else
 				formspec[n] = string.format("image[%g,%g;%g,%g;%s^[colorize:#808080:alpha]",
 					pos_x, pos_y, style.btn_size, style.btn_size,
 					def.image)
 				n = n+1
-				i = i + 1
 			end
 		end
 	end
@@ -363,7 +362,7 @@ function ui.apply_filter(player, filter, search_dir)
 			return true
 		end
 	else
-		-- Name filter: fuzzy match item names and descriptions 
+		-- Name filter: fuzzy match item names and descriptions
 		local player_info = minetest.get_player_information(player_name)
 		local lang = player_info and player_info.lang_code or ""
 

--- a/internal.lua
+++ b/internal.lua
@@ -1,6 +1,7 @@
 local S = minetest.get_translator("unified_inventory")
 local F = minetest.formspec_escape
 local ui = unified_inventory
+local hide_disabled_buttons = ui.hide_disabled_buttons
 
 -- This pair of encoding functions is used where variable text must go in
 -- button names, where the text might contain formspec metacharacters.
@@ -65,8 +66,9 @@ local function formspec_tab_buttons(player, formspec, style)
 		style.main_button_cols * style.btn_spc, style.main_button_rows -- size
 	)
 	n = n + 1
+	local i = 1
 
-	for i, def in pairs(filtered_inv_buttons) do
+	for _, def in pairs(filtered_inv_buttons) do
 		local pos_x =           ((i - 1) % style.main_button_cols) * style.btn_spc
 		local pos_y = math.floor((i - 1) / style.main_button_cols) * style.btn_spc
 
@@ -78,11 +80,14 @@ local function formspec_tab_buttons(player, formspec, style)
 					F(def.name))
 				formspec[n+1] = "tooltip["..F(def.name)..";"..(def.tooltip or "").."]"
 				n = n+2
-			else
+				i = i + 1
+
+			elseif not hide_disabled_buttons then
 				formspec[n] = string.format("image[%g,%g;%g,%g;%s^[colorize:#808080:alpha]",
 					pos_x, pos_y, style.btn_size, style.btn_size,
 					def.image)
 				n = n+1
+				i = i + 1
 			end
 		end
 	end

--- a/internal.lua
+++ b/internal.lua
@@ -1,7 +1,6 @@
 local S = minetest.get_translator("unified_inventory")
 local F = minetest.formspec_escape
 local ui = unified_inventory
-local hide_disabled_buttons = ui.hide_disabled_buttons
 
 -- This pair of encoding functions is used where variable text must go in
 -- button names, where the text might contain formspec metacharacters.
@@ -55,7 +54,7 @@ local function formspec_tab_buttons(player, formspec, style)
 
 	for _, def in pairs(ui.buttons) do
 		if not (style.is_lite_mode and def.hide_lite) then
-			if (def.condition == nil or def.condition(player) or not hide_disabled_buttons) then
+			if def.condition == nil or def.condition(player) or not ui.hide_disabled_buttons then
 				table.insert(filtered_inv_buttons, def)
 			end
 		end

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -10,5 +10,8 @@ unified_inventory_bags (Enable bags) bool true
 #and the give privilege.
 unified_inventory_trash (Enable trash) bool true
 
+#If enabled, disabled buttons will be hidden instead of grayed out.
+unified_inventory_hide_disabled_buttons (Hide disabled buttons) bool false
+
 
 unified_inventory_automatic_categorization (Items automatically added to categories) bool true


### PR DESCRIPTION
useless buttons take up valuable screen real-estate. this creates a config option to hide them. default behavior is unchanged. 