### PR TITLE
remove dependency on farming

### DIFF
--- a/mod.conf
+++ b/mod.conf
@@ -1,6 +1,6 @@
 name = unified_inventory
 
-optional_depends = default, creative, sfinv, datastorage, farming
+optional_depends = default, creative, sfinv, datastorage
 description = """
 Unified Inventory replaces the default survival and creative inventory.
 It adds a nicer interface and a number of features, such as a crafting guide.


### PR DESCRIPTION
currently, there is an optional dependency on farming, in order to craft inventory bags out of cotton and string. this is not needed - the recipes will continue to function when farming is present, whether this mod depends on it or not. 

depending on farming causes problems. farming depends on stairs. if i want to create an alternate "stairs" implementation which registers custom recipe types with unified inventory, we now have a dependency cycle.

ideally the bags (content) should be excised from the core of unified_inventory, which should just be an API, but that's a lot of work. 