### PR TITLE
Improve button scrollbar max calculation

### DIFF
--- a/internal.lua
+++ b/internal.lua
@@ -91,9 +91,10 @@ local function formspec_tab_buttons(player, formspec, style)
 	end
 	formspec[n] = "scroll_container_end[]"
 	if needs_scrollbar then
+		local total_rows = math.ceil(#filtered_inv_buttons / style.main_button_cols)
 		formspec[n+1] = ("scrollbaroptions[max=%i;arrows=hide]"):format(
 			-- This calculation is not 100% accurate but "good enough"
-			math.ceil((#filtered_inv_buttons - 1) / style.main_button_cols) * style.btn_spc * 5
+			(total_rows - style.main_button_rows) * style.btn_spc * 10
 		)
 		formspec[n+2] = ("scrollbar[%g,%g;0.4,%g;vertical;tabbtnscroll;0]"):format(
 			style.main_button_x + style.main_button_cols * style.btn_spc - 0.1, -- x pos


### PR DESCRIPTION
This fixes an off by one issue with the calculation (shown below) and makes it work properly with more than 2 rows of buttons.

Before:
![image](https://user-images.githubusercontent.com/3182651/209881491-e8e9f55e-33a9-495a-9759-c5bab293a249.png)

After:
![image](https://user-images.githubusercontent.com/3182651/209881416-3d5cf9a4-3a7a-47f7-a9bb-f25141dbea82.png)