### PR TITLE
Centre page number label and move refill/trash labels

### DIFF
--- a/internal.lua
+++ b/internal.lua
@@ -274,9 +274,11 @@ local function formspec_add_item_browser(player, formspec, ui_peruser)
 			end
 		end
 	end
-	formspec[n] = string.format("label[%f,%f;%s: %s]",
-		ui_peruser.page_buttons_x + ui_peruser.btn_spc * (ui_peruser.is_lite_mode and 1 or 2),
-		ui_peruser.page_buttons_y + 0.1 + ui_peruser.btn_spc * 2,
+	formspec[n] = "style[page_number;content_offset=0]"
+	formspec[n + 1] = string.format("image_button[%f,%f;%f,0.4;;page_number;%s: %s;false;false;]",
+		ui_peruser.page_buttons_x,
+		ui_peruser.page_buttons_y + ui_peruser.btn_spc * 2 - 0.1,
+		ui_peruser.btn_spc * (bn - 1) + ui_peruser.btn_size,
 		F(S("Page")), S("@1 of @2",page2,pagemax))
 end
 

--- a/register.lua
+++ b/register.lua
@@ -183,14 +183,14 @@ ui.register_page("craft", {
 		local n=#formspec+1
 
 		if ui.trash_enabled or ui.is_creative(player_name) or minetest.get_player_privs(player_name).give then
-			formspec[n] = string.format("label[%f,%f;%s]", craftx + 6.45, crafty + 2.4, F(S("Trash:")))
+			formspec[n] = string.format("label[%f,%f;%s]", craftx + 6.35, crafty + 2.3, F(S("Trash:")))
 			formspec[n+1] = ui.make_trash_slot(craftx + 6.25, crafty + 2.5)
 			n=n + 2
 		end
 
 		if ui.is_creative(player_name) then
 			formspec[n] = ui.single_slot(craftx - 2.5, crafty + 2.5)
-			formspec[n+1] = string.format("label[%f,%f;%s]", craftx - 2.3, crafty + 2.4,F(S("Refill:")))
+			formspec[n+1] = string.format("label[%f,%f;%s]", craftx - 2.4, crafty + 2.3, F(S("Refill:")))
 			formspec[n+2] = string.format("list[detached:%srefill;main;%f,%f;1,1;]",
 				F(player_name), craftx - 2.5 + ui.list_img_offset, crafty + 2.5 + ui.list_img_offset)
 		end


### PR DESCRIPTION
This PR centres the page number label by using an `image_button` and moves the refill and trash labels slightly further up and to the left.

Note that the relative positioning and size of the labels will differ depending on your screen size, display density, and font size.

<details>
<summary>Screenshots with a window size of 1920x1080</summary>

**Before:**
![image](https://user-images.githubusercontent.com/3182651/210159285-96e1dd96-e772-432f-8363-916d4459ec44.png)

**After:**
![image](https://user-images.githubusercontent.com/3182651/210159280-ce5a042a-42cb-4a5d-9fac-41b2dced3300.png)

</details>

<details>
<summary>Screenshots with a window size of 1400x900</summary>

**Before:**
![image](https://user-images.githubusercontent.com/3182651/210159211-b9cda534-2817-4756-88ca-5586ecd5b602.png)

**After:**
![image](https://user-images.githubusercontent.com/3182651/210159200-b81cadcc-8d79-427b-b2c1-34a79c7270d4.png)

</details>