### PR TITLE
clean itemname before checking existence

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -12,8 +12,14 @@ local function is_recipe_craftable(recipe)
 			end
 		else
 			-- Possibly an item
-			if not minetest.registered_items[itemname]
-					or minetest.get_item_group(itemname, "not_in_craft_guide") ~= 0 then
+			local itemname_cleaned = ""
+			for s in itemname:gmatch("%S+") do
+				if itemname_cleaned == "" then
+					itemname_cleaned = s
+				end
+			end
+			if not minetest.registered_items[itemname_cleaned]
+					or minetest.get_item_group(itemname_cleaned, "not_in_craft_guide") ~= 0 then
 				return false
 			end
 		end


### PR DESCRIPTION
Otherwise, UI checks the existence of items like `abriglass:stained_glass_hardware 1 0 \"\\u0001description\\u0002green glass\\u0003palette_index\\u00023\\u0003\"` (what won't work *lol*).

How to test:
1. Install https://github.com/mt-mods/abriglass
2. Test if UI shows the recipes for hardware colored glass