### PR TITLE
Added `unified_inventory_enable_item_names` option

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -191,7 +191,8 @@ dofile(modpath.."/register.lua")
 if minetest.settings:get_bool("unified_inventory_bags") ~= false then
 	dofile(modpath.."/bags.lua")
 end
-
-dofile(modpath.."/item_names.lua")
+if minetest.settings:get_bool("unified_inventory_enable_item_names") == true then
+	dofile(modpath.."/item_names.lua")
+end 
 dofile(modpath.."/waypoints.lua")
 dofile(modpath.."/legacy.lua") -- mod compatibility

--- a/init.lua
+++ b/init.lua
@@ -191,7 +191,7 @@ dofile(modpath.."/register.lua")
 if minetest.settings:get_bool("unified_inventory_bags") ~= false then
 	dofile(modpath.."/bags.lua")
 end
-if minetest.settings:get_bool("unified_inventory_enable_item_names") == true then
+if minetest.settings:get_bool("unified_inventory_enable_item_names") ~= false then
 	dofile(modpath.."/item_names.lua")
 end 
 dofile(modpath.."/waypoints.lua")

--- a/init.lua
+++ b/init.lua
@@ -193,6 +193,6 @@ if minetest.settings:get_bool("unified_inventory_bags") ~= false then
 end
 if minetest.settings:get_bool("unified_inventory_item_names") ~= false then
 	dofile(modpath.."/item_names.lua")
-end 
+end
 dofile(modpath.."/waypoints.lua")
 dofile(modpath.."/legacy.lua") -- mod compatibility

--- a/init.lua
+++ b/init.lua
@@ -191,7 +191,7 @@ dofile(modpath.."/register.lua")
 if minetest.settings:get_bool("unified_inventory_bags") ~= false then
 	dofile(modpath.."/bags.lua")
 end
-if minetest.settings:get_bool("unified_inventory_enable_item_names") ~= false then
+if minetest.settings:get_bool("unified_inventory_item_names") ~= false then
 	dofile(modpath.."/item_names.lua")
 end 
 dofile(modpath.."/waypoints.lua")

--- a/item_names.lua
+++ b/item_names.lua
@@ -3,6 +3,9 @@
 local item_names = {} -- [player_name] = { hud, dtime, itemname }
 local dlimit = 3  -- HUD element will be hidden after this many seconds
 local hudbars_mod = minetest.get_modpath("hudbars")
+local only_names = minetest.settings:get_bool("unified_inventory_only_names")
+local shorten_names = minetest.settings:get_bool("unified_inventory_shorten_names")
+local max_length = tonumber(minetest.settings:get("unified_inventory_max_item_name_length")) or 80
 
 local function set_hud(player)
 	local player_name = player:get_player_name()
@@ -68,6 +71,20 @@ minetest.register_globalstep(function(dtime)
 				-- Try to use default description when none is set in the meta
 				local def = minetest.registered_items[itemname]
 				desc = def and def.description or ""
+			end
+			if only_names and desc and string.find(desc, "\n") then
+				desc = string.match(desc, "([^\n]*)")
+			end
+			if shorten_names and string.len(desc) > max_length then
+				local prefix_end = string.find(desc, ")") -- Some items have prefix: @#35cdff)Desert Eagle, @default)Locked Chest
+				if not prefix_end then
+					prefix_end = 1
+				end
+				if max_length > 0 then
+					desc = string.sub(desc, prefix_end + 1 , max_length + prefix_end) .. " [...]"
+				else
+					desc = ""
+				end
 			end
 			player:hud_change(data.hud, 'text', desc)
 		end

--- a/item_names.lua
+++ b/item_names.lua
@@ -4,7 +4,6 @@ local item_names = {} -- [player_name] = { hud, dtime, itemname }
 local dlimit = 3  -- HUD element will be hidden after this many seconds
 local hudbars_mod = minetest.get_modpath("hudbars")
 local only_names = minetest.settings:get_bool("unified_inventory_only_names")
-local shorten_names = minetest.settings:get_bool("unified_inventory_shorten_names")
 local max_length = tonumber(minetest.settings:get("unified_inventory_max_item_name_length")) or 80
 
 local function set_hud(player)
@@ -75,16 +74,10 @@ minetest.register_globalstep(function(dtime)
 			if only_names and desc and string.find(desc, "\n") then
 				desc = string.match(desc, "([^\n]*)")
 			end
-			if shorten_names and string.len(desc) > max_length then
-				local prefix_end = string.find(desc, ")") -- Some items have prefix: @#35cdff)Desert Eagle, @default)Locked Chest
-				if not prefix_end then
-					prefix_end = 1
-				end
-				if max_length > 0 then
-					desc = string.sub(desc, prefix_end + 1 , max_length + prefix_end) .. " [...]"
-				else
-					desc = ""
-				end
+			if not (max_length <= 0) and string.len(desc) > max_length then
+				desc = minetest.strip_colors(desc) -- FIXME: @default) is not getting removed
+				desc = string.sub(desc, 1 , max_length) .. " [...]"
+
 			end
 			player:hud_change(data.hud, 'text', desc)
 		end

--- a/item_names.lua
+++ b/item_names.lua
@@ -62,6 +62,7 @@ minetest.register_globalstep(function(dtime)
 			data.itemname = itemname
 			data.index = index
 			data.dtime = 0
+			local lang_code = minetest.get_player_information(player:get_player_name()).lang_code
 
 			local desc = stack.get_meta
 				and stack:get_meta():get_string("description")
@@ -74,10 +75,10 @@ minetest.register_globalstep(function(dtime)
 			if only_names and desc and string.find(desc, "\n") then
 				desc = string.match(desc, "([^\n]*)")
 			end
-			if not (max_length <= 0) and string.len(desc) > max_length then
-				desc = minetest.strip_colors(desc) -- FIXME: @default) is not getting removed
-				desc = string.sub(desc, 1 , max_length) .. " [...]"
-
+			desc = minetest.get_translated_string(lang_code, desc)
+			desc = minetest.strip_colors(desc)
+			if string.len(desc) > max_length and max_length > 0 then
+				desc = string.sub(desc, 1, max_length) .. " [...]"
 			end
 			player:hud_change(data.hud, 'text', desc)
 		end

--- a/item_names.lua
+++ b/item_names.lua
@@ -3,7 +3,7 @@
 local item_names = {} -- [player_name] = { hud, dtime, itemname }
 local dlimit = 3  -- HUD element will be hidden after this many seconds
 local hudbars_mod = minetest.get_modpath("hudbars")
-local only_names = minetest.settings:get_bool("unified_inventory_only_names")
+local only_names = minetest.settings:get_bool("unified_inventory_only_names", true)
 local max_length = tonumber(minetest.settings:get("unified_inventory_max_item_name_length")) or 80
 
 local function set_hud(player)

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -15,3 +15,5 @@ unified_inventory_hide_disabled_buttons (Hide disabled buttons) bool false
 
 
 unified_inventory_automatic_categorization (Items automatically added to categories) bool true
+
+unified_inventory_enable_item_names (Item names are shown above hotbar) bool true

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -16,4 +16,10 @@ unified_inventory_hide_disabled_buttons (Hide disabled buttons) bool false
 
 unified_inventory_automatic_categorization (Items automatically added to categories) bool true
 
-unified_inventory_enable_item_names (Item names are shown above hotbar) bool true
+unified_inventory_item_names (Item names are shown above hotbar) bool true
+
+unified_inventory_only_names (Show only item name) bool true
+
+unified_inventory_shorten_names (Shorten long item names) bool true
+
+unified_inventory_max_item_name_length (Maximum length of an item name before it's truncated) int 80

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -20,6 +20,4 @@ unified_inventory_item_names (Item names are shown above hotbar) bool true
 
 unified_inventory_only_names (Show only item name) bool true
 
-unified_inventory_shorten_names (Shorten long item names) bool true
-
-unified_inventory_max_item_name_length (Maximum length of an item name before it's truncated) int 80
+unified_inventory_max_item_name_length (Maximum length of an item name before it's truncated, 0 disables option) int 80


### PR DESCRIPTION
Added option to disable Item Names.
### Purpose of change
This change allows players to disable item names, addressing the issue of long item descriptions taking up too much screen space in certain mods (e.g., ranged weapons).
### Alternative solution
Show only first line of Item's description