### PR TITLE
Remove all `not_in_creative_inventory` items from craftguide

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -198,11 +198,21 @@ minetest.after(0.01, function()
 				]]
 				cat_def[itemname] = nil
 			end
+			if minetest.registered_items[itemname] and minetest.registered_items[itemname].groups.not_in_creative_inventory then
+				total_removed = total_removed + 1
+				--[[
+				-- For analysis
+				minetest.log("warning", "[unified_inventory] Removed item '"
+					.. itemname .. "' from category '" .. cat_name
+					.. "'. Reason: item is in 'not_in_creative_inventory' group")
+				--]]
+				cat_def[itemname] = nil
+			end
 		end
 	end
 	if total_removed > 0 then
 		minetest.log("info", "[unified_inventory] Removed " .. total_removed ..
-			" unknown items from the categories.")
+			" items from the categories.")
 	end
 
 	for _, callback in ipairs(ui.initialized_callbacks) do

--- a/api.lua
+++ b/api.lua
@@ -205,7 +205,7 @@ minetest.after(0.01, function()
 				minetest.log("warning", "[unified_inventory] Removed item '"
 					.. itemname .. "' from category '" .. cat_name
 					.. "'. Reason: item is in 'not_in_creative_inventory' group")
-				--]]
+				]]
 				cat_def[itemname] = nil
 			end
 		end


### PR DESCRIPTION
This removes all `not_in_creative_inventory` items from the craftguide.

<details>
<summary>List of removed items on my mod soup setup</summary>

```lua
2024-03-18 15:02:30: WARNING[Server]: [unified_inventory] Removed item 'default:grass_2' from category 'plants'. Reason: item is in 'not_in_creative_inventory' group
2024-03-18 15:02:30: WARNING[Server]: [unified_inventory] Removed item 'default:grass_3' from category 'plants'. Reason: item is in 'not_in_creative_inventory' group
2024-03-18 15:02:30: WARNING[Server]: [unified_inventory] Removed item 'default:grass_4' from category 'plants'. Reason: item is in 'not_in_creative_inventory' group
2024-03-18 15:02:30: WARNING[Server]: [unified_inventory] Removed item 'default:grass_5' from category 'plants'. Reason: item is in 'not_in_creative_inventory' group
2024-03-18 15:02:30: WARNING[Server]: [unified_inventory] Removed item 'default:dry_grass_2' from category 'plants'. Reason: item is in 'not_in_creative_inventory' group
2024-03-18 15:02:30: WARNING[Server]: [unified_inventory] Removed item 'farming:cotton_1' from category 'plants'. Reason: item is in 'not_in_creative_inventory' group
2024-03-18 15:02:30: WARNING[Server]: [unified_inventory] Removed item 'farming:cotton_2' from category 'plants'. Reason: item is in 'not_in_creative_inventory' group
2024-03-18 15:02:30: WARNING[Server]: [unified_inventory] Removed item 'farming:cotton_3' from category 'plants'. Reason: item is in 'not_in_creative_inventory' group
2024-03-18 15:02:30: WARNING[Server]: [unified_inventory] Removed item 'farming:cotton_4' from category 'plants'. Reason: item is in 'not_in_creative_inventory' group
2024-03-18 15:02:30: WARNING[Server]: [unified_inventory] Removed item 'farming:cotton_5' from category 'plants'. Reason: item is in 'not_in_creative_inventory' group
2024-03-18 15:02:30: WARNING[Server]: [unified_inventory] Removed item 'farming:cotton_6' from category 'plants'. Reason: item is in 'not_in_creative_inventory' group
2024-03-18 15:02:30: WARNING[Server]: [unified_inventory] Removed item 'farming:cotton_7' from category 'plants'. Reason: item is in 'not_in_creative_inventory' group
2024-03-18 15:02:30: WARNING[Server]: [unified_inventory] Removed item 'farming:cotton_8' from category 'plants'. Reason: item is in 'not_in_creative_inventory' group
2024-03-18 15:02:30: WARNING[Server]: [unified_inventory] Removed item 'default:fern_3' from category 'plants'. Reason: item is in 'not_in_creative_inventory' group
2024-03-18 15:02:30: WARNING[Server]: [unified_inventory] Removed item 'default:marram_grass_2' from category 'plants'. Reason: item is in 'not_in_creative_inventory' group
2024-03-18 15:02:30: WARNING[Server]: [unified_inventory] Removed item 'default:marram_grass_3' from category 'plants'. Reason: item is in 'not_in_creative_inventory' group
2024-03-18 15:02:30: WARNING[Server]: [unified_inventory] Removed item 'flowers:waterlily_waving' from category 'plants'. Reason: item is in 'not_in_creative_inventory' group
2024-03-18 15:02:30: WARNING[Server]: [unified_inventory] Removed item 'farming:wheat_8' from category 'plants'. Reason: item is in 'not_in_creative_inventory' group
2024-03-18 15:02:30: WARNING[Server]: [unified_inventory] Removed item 'farming:wheat_7' from category 'plants'. Reason: item is in 'not_in_creative_inventory' group
2024-03-18 15:02:30: WARNING[Server]: [unified_inventory] Removed item 'farming:wheat_6' from category 'plants'. Reason: item is in 'not_in_creative_inventory' group
2024-03-18 15:02:30: WARNING[Server]: [unified_inventory] Removed item 'farming:wheat_5' from category 'plants'. Reason: item is in 'not_in_creative_inventory' group
2024-03-18 15:02:30: WARNING[Server]: [unified_inventory] Removed item 'farming:wheat_4' from category 'plants'. Reason: item is in 'not_in_creative_inventory' group
2024-03-18 15:02:30: WARNING[Server]: [unified_inventory] Removed item 'farming:wheat_3' from category 'plants'. Reason: item is in 'not_in_creative_inventory' group
2024-03-18 15:02:30: WARNING[Server]: [unified_inventory] Removed item 'farming:wheat_2' from category 'plants'. Reason: item is in 'not_in_creative_inventory' group
2024-03-18 15:02:30: WARNING[Server]: [unified_inventory] Removed item 'farming:wheat_1' from category 'plants'. Reason: item is in 'not_in_creative_inventory' group
2024-03-18 15:02:30: WARNING[Server]: [unified_inventory] Removed item 'default:fern_2' from category 'plants'. Reason: item is in 'not_in_creative_inventory' group
2024-03-18 15:02:30: WARNING[Server]: [unified_inventory] Removed item 'default:dry_grass_5' from category 'plants'. Reason: item is in 'not_in_creative_inventory' group
2024-03-18 15:02:30: WARNING[Server]: [unified_inventory] Removed item 'default:dry_grass_4' from category 'plants'. Reason: item is in 'not_in_creative_inventory' group
2024-03-18 15:02:30: WARNING[Server]: [unified_inventory] Removed item 'default:apple_mark' from category 'plants'. Reason: item is in 'not_in_creative_inventory' group
2024-03-18 15:02:30: WARNING[Server]: [unified_inventory] Removed item 'default:dry_grass_3' from category 'plants'. Reason: item is in 'not_in_creative_inventory' group
2024-03-18 15:02:30: WARNING[Server]: [unified_inventory] Removed item 'techage:sieved_basalt_gravel' from category 'stairsplus:cuttable'. Reason: item is in 'not_in_creative_inventory' group
2024-03-18 15:02:30: WARNING[Server]: [unified_inventory] Removed item 'farming:hoe_bronze' from category 'tools'. Reason: item is in 'not_in_creative_inventory' group
2024-03-18 15:02:30: WARNING[Server]: [unified_inventory] Removed item 'farming:hoe_diamond' from category 'tools'. Reason: item is in 'not_in_creative_inventory' group
2024-03-18 15:02:30: WARNING[Server]: [unified_inventory] Removed item 'farming:hoe_mese' from category 'tools'. Reason: item is in 'not_in_creative_inventory' group
2024-03-18 15:02:30: WARNING[Server]: [unified_inventory] Removed item 'default:torch_wall' from category 'lighting'. Reason: item is in 'not_in_creative_inventory' group
2024-03-18 15:02:30: WARNING[Server]: [unified_inventory] Removed item 'default:torch_ceiling' from category 'lighting'. Reason: item is in 'not_in_creative_inventory' group
2024-03-18 15:02:30: WARNING[Server]: [unified_inventory] Removed item 'air' from category 'environment'. Reason: item is in 'not_in_creative_inventory' group
2024-03-18 15:02:30: WARNING[Server]: [unified_inventory] Removed item 'default:water_flowing' from category 'environment'. Reason: item is in 'not_in_creative_inventory' group
2024-03-18 15:02:30: WARNING[Server]: [unified_inventory] Removed item 'default:river_water_flowing' from category 'environment'. Reason: item is in 'not_in_creative_inventory' group
2024-03-18 15:02:30: WARNING[Server]: [unified_inventory] Removed item 'default:cave_ice' from category 'environment'. Reason: item is in 'not_in_creative_inventory' group
2024-03-18 15:02:30: WARNING[Server]: [unified_inventory] Removed item 'farming:desert_sand_soil' from category 'environment'. Reason: item is in 'not_in_creative_inventory' group
2024-03-18 15:02:30: WARNING[Server]: [unified_inventory] Removed item 'farming:desert_sand_soil_wet' from category 'environment'. Reason: item is in 'not_in_creative_inventory' group
2024-03-18 15:02:30: WARNING[Server]: [unified_inventory] Removed item 'farming:dry_soil' from category 'environment'. Reason: item is in 'not_in_creative_inventory' group
2024-03-18 15:02:30: WARNING[Server]: [unified_inventory] Removed item 'farming:dry_soil_wet' from category 'environment'. Reason: item is in 'not_in_creative_inventory' group
2024-03-18 15:02:30: WARNING[Server]: [unified_inventory] Removed item 'farming:soil' from category 'environment'. Reason: item is in 'not_in_creative_inventory' group
2024-03-18 15:02:30: WARNING[Server]: [unified_inventory] Removed item 'default:dirt_with_grass_footsteps' from category 'environment'. Reason: item is in 'not_in_creative_inventory' group
2024-03-18 15:02:30: WARNING[Server]: [unified_inventory] Removed item 'farming:soil_wet' from category 'environment'. Reason: item is in 'not_in_creative_inventory' group
2024-03-18 15:02:30: WARNING[Server]: [unified_inventory] Removed item 'default:lava_flowing' from category 'environment'. Reason: item is in 'not_in_creative_inventory' group
```

</details>

`Air` is still is in the environment category although it has been removed from this category, not sure why.....
Doesn't seem to break anything.