### PR TITLE
prevent crash when clicking unknown item in the recipe

### DIFF
--- a/register.lua
+++ b/register.lua
@@ -329,7 +329,7 @@ ui.register_page("craftguide", {
 		local giveme_form =
 			"label[" .. (give_x + 0.1) .. "," .. (craftguidey + 2.7) .. ";" .. F(S("Give me:")) .. "]" ..
 			"button[" .. (give_x) .. "," .. (craftguidey + 2.9) .. ";0.75,0.5;craftguide_giveme_1;1]"
-		if item_def.type ~= "tool" then
+		if item_def and item_def.type ~= "tool" then
 			giveme_form = giveme_form ..
 				"button[" .. (give_x + 0.8) .. "," .. (craftguidey + 2.9) .. ";0.75,0.5;craftguide_giveme_10;10]" ..
 				"button[" .. (give_x + 1.6) .. "," .. (craftguidey + 2.9) .. ";0.75,0.5;craftguide_giveme_99;99]"


### PR DESCRIPTION
Got this crash when someone clicked an unknown item in the broken recipe:

``` ERROR[Main]: ServerError: AsyncErr: Lua: Runtime error from mod '' in callback on_playerReceiveFields(): ...mods/unified_inventory/register.lua:332: attempt to index local 'item_def' (a nil value)
 ERROR[Main]: stack traceback:
 ERROR[Main]: .../mods/unified_inventory/register.lua:332: in function 'get_formspec'
 ERROR[Main]: .../mods/unified_inventory/internal.lua:309: in function 'get_formspec'
 ERROR[Main]: .../mods/unified_inventory/internal.lua:334: in function 'set_inventory_formspec'
 ERROR[Main]: .../mods/unified_inventory/callbacks.lua:209: in function 'func'
 ERROR[Main]: .../builtin/profiler/instrumentation.lua:124: in function <.../builtin/profiler/instrumentation.lua:117>
 ERROR[Main]: .../builtin/common/register.lua:26: in function <.../builtin/common/register.lua:12>
```

unknown items should not exist normally, but it's also better to not crash at least :)