### PR TITLE
Refactor 'compute_group_item' and related functions

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -2,19 +2,26 @@ local S = minetest.get_translator("unified_inventory")
 local F = minetest.formspec_escape
 local ui = unified_inventory
 
+--- @return boolean. Returns `true` when all ingredients exist.
 local function is_recipe_craftable(recipe)
 	-- Ensure the ingedients exist
 	for _, itemname in pairs(recipe.items) do
 		local groups = string.find(itemname, "group:")
 		if groups then
-			if not ui.get_group_item(string.sub(groups, 8)).item then
+			local items = ui.get_matching_items(itemname)
+			if not next(items) then
+				--print("No items for group item: ", itemname)
 				return false
 			end
 		else
-			-- Possibly an item
-			local itemname_cleaned = ItemStack(itemname):get_name()
-			if not minetest.registered_items[itemname_cleaned]
-					or minetest.get_item_group(itemname_cleaned, "not_in_craft_guide") ~= 0 then
+			-- Possibly an item. Clean its name (could be "default:stick 4")
+			itemname = ItemStack(itemname):get_name()
+			local def = core.registered_items[itemname]
+			if not def then
+				return false
+			end
+			-- inlined core.get_item_group
+			if (def.groups.not_in_craft_guide or 0) ~= 0 then
 				return false
 			end
 		end
@@ -22,8 +29,7 @@ local function is_recipe_craftable(recipe)
 	return true
 end
 
--- Create detached creative inventory after loading all mods
-minetest.after(0.01, function()
+local function register_normal_craft_recipes()
 	local rev_aliases = {}
 	for original, newname in pairs(minetest.registered_aliases) do
 		if not rev_aliases[newname] then
@@ -32,23 +38,120 @@ minetest.after(0.01, function()
 		table.insert(rev_aliases[newname], original)
 	end
 
+	for _, name in ipairs(ui.items_list) do
+		-- Alias processing: Find recipes that belong to the current item name
+		local all_names = rev_aliases[name] or {}
+		table.insert(all_names, name)
+		for _, itemname in ipairs(all_names) do
+			local recipes = minetest.get_all_craft_recipes(itemname)
+			for _, recipe in ipairs(recipes or {}) do
+				if is_recipe_craftable(recipe) then
+					ui.register_craft(recipe)
+				end
+			end
+		end
+	end
+end
+
+local function register_dig_drops(name)
+	-- Analyse dropped items -> custom "digging" recipes
+	local def = minetest.registered_items[name]
+	-- Simple drops
+	if type(def.drop) == "string" then
+		local dstack = ItemStack(def.drop)
+		if not dstack:is_empty() and dstack:get_name() ~= name then
+			ui.register_craft({
+				type = "digging",
+				items = {name},
+				output = def.drop,
+				width = 0,
+			})
+
+		end
+	-- Complex drops. Yes, it's really complex!
+	elseif type(def.drop) == "table" then
+		--[[ Extract single items from the table and save them into dedicated tables
+		to register them later, in order to avoid duplicates. These tables counts
+		the total number of guaranteed drops and drops by chance (“maybes”) for each item.
+		For “maybes”, the final count is the theoretical maximum number of items, not
+		neccessarily the actual drop count. ]]
+		local drop_guaranteed = {}
+		local drop_maybe = {}
+		-- This is for catching an obscure corner case: If the top items table has
+		-- only items with rarity = 1, but max_items is set, then only the first
+		-- max_items will be part of the drop, any later entries are logically
+		-- impossible, so this variable is for keeping track of this
+		local max_items_left = def.drop.max_items
+		-- For checking whether we still encountered only guaranteed only so far;
+		-- for the first “maybe” item it will become false which will cause ALL
+		-- later items to be considered “maybes”.
+		-- A common idiom is:
+		-- { max_items 1, { items = {
+		--	{ items={"example:1"}, rarity = 5 },
+		-- 	{ items={"example:2"}, rarity = 1 }, }}}
+		-- example:2 must be considered a “maybe” because max_items is set and it
+		-- appears after a “maybe”
+		local max_start = true
+		-- Let's iterate through the items madness!
+		-- Handle invalid drop entries gracefully.
+		local drop_items = def.drop.items or { }
+		for i=1,#drop_items do
+			if max_items_left ~= nil and max_items_left <= 0 then break end
+			local itit = drop_items[i]
+			for j=1,#itit.items do
+				local dstack = ItemStack(itit.items[j])
+				if not dstack:is_empty() and dstack:get_name() ~= name then
+					local dname = dstack:get_name()
+					local dcount = dstack:get_count()
+					-- Guaranteed drops AND we are not yet in “maybe mode”
+					if #itit.items == 1 and itit.rarity == 1 and max_start then
+						if drop_guaranteed[dname] == nil then
+							drop_guaranteed[dname] = 0
+						end
+						drop_guaranteed[dname] = drop_guaranteed[dname] + dcount
+
+						if max_items_left ~= nil then
+							max_items_left = max_items_left - 1
+							if max_items_left <= 0 then break end
+						end
+					-- Drop was a “maybe”
+					else
+						if max_items_left ~= nil then max_start = false end
+						if drop_maybe[dname] == nil then
+							drop_maybe[dname] = 0
+						end
+						drop_maybe[dname] = drop_maybe[dname] + dcount
+					end
+				end
+			end
+		end
+		for itemstring, count in pairs(drop_guaranteed) do
+			ui.register_craft({
+				type = "digging",
+				items = {name},
+				output = itemstring .. " " .. count,
+				width = 0,
+			})
+		end
+		for itemstring, count in pairs(drop_maybe) do
+			ui.register_craft({
+				type = "digging_chance",
+				items = {name},
+				output = itemstring .. " " .. count,
+				width = 0,
+			})
+		end
+	end
+end
+
+-- Create detached creative inventory after loading all mods
+minetest.after(0.01, function()
+
 	-- Filtered item list
 	ui.items_list = {}
 	for name, def in pairs(minetest.registered_items) do
 		if ui.is_itemdef_listable(def) then
 			table.insert(ui.items_list, name)
-
-			-- Alias processing: Find recipes that belong to the current item name
-			local all_names = rev_aliases[name] or {}
-			table.insert(all_names, name)
-			for _, itemname in ipairs(all_names) do
-				local recipes = minetest.get_all_craft_recipes(itemname)
-				for _, recipe in ipairs(recipes or {}) do
-					if is_recipe_craftable(recipe) then
-						ui.register_craft(recipe)
-					end
-				end
-			end
 		end
 	end
 
@@ -56,99 +159,14 @@ minetest.after(0.01, function()
 	ui.items_list_size = #ui.items_list
 	print("Unified Inventory. Inventory size: "..ui.items_list_size)
 
-	-- Analyse dropped items -> custom "digging" recipes
-	for _, name in ipairs(ui.items_list) do
-		local def = minetest.registered_items[name]
-		-- Simple drops
-		if type(def.drop) == "string" then
-			local dstack = ItemStack(def.drop)
-			if not dstack:is_empty() and dstack:get_name() ~= name then
-				ui.register_craft({
-					type = "digging",
-					items = {name},
-					output = def.drop,
-					width = 0,
-				})
-
-			end
-		-- Complex drops. Yes, it's really complex!
-		elseif type(def.drop) == "table" then
-			--[[ Extract single items from the table and save them into dedicated tables
-			to register them later, in order to avoid duplicates. These tables counts
-			the total number of guaranteed drops and drops by chance (“maybes”) for each item.
-			For “maybes”, the final count is the theoretical maximum number of items, not
-			neccessarily the actual drop count. ]]
-			local drop_guaranteed = {}
-			local drop_maybe = {}
-			-- This is for catching an obscure corner case: If the top items table has
-			-- only items with rarity = 1, but max_items is set, then only the first
-			-- max_items will be part of the drop, any later entries are logically
-			-- impossible, so this variable is for keeping track of this
-			local max_items_left = def.drop.max_items
-			-- For checking whether we still encountered only guaranteed only so far;
-			-- for the first “maybe” item it will become false which will cause ALL
-			-- later items to be considered “maybes”.
-			-- A common idiom is:
-			-- { max_items 1, { items = {
-			--	{ items={"example:1"}, rarity = 5 },
-			-- 	{ items={"example:2"}, rarity = 1 }, }}}
-			-- example:2 must be considered a “maybe” because max_items is set and it
-			-- appears after a “maybe”
-			local max_start = true
-			-- Let's iterate through the items madness!
-			-- Handle invalid drop entries gracefully.
-			local drop_items = def.drop.items or { }
-			for i=1,#drop_items do
-				if max_items_left ~= nil and max_items_left <= 0 then break end
-				local itit = drop_items[i]
-				for j=1,#itit.items do
-					local dstack = ItemStack(itit.items[j])
-					if not dstack:is_empty() and dstack:get_name() ~= name then
-						local dname = dstack:get_name()
-						local dcount = dstack:get_count()
-						-- Guaranteed drops AND we are not yet in “maybe mode”
-						if #itit.items == 1 and itit.rarity == 1 and max_start then
-							if drop_guaranteed[dname] == nil then
-								drop_guaranteed[dname] = 0
-							end
-							drop_guaranteed[dname] = drop_guaranteed[dname] + dcount
-
-							if max_items_left ~= nil then
-								max_items_left = max_items_left - 1
-								if max_items_left <= 0 then break end
-							end
-						-- Drop was a “maybe”
-						else
-							if max_items_left ~= nil then max_start = false end
-							if drop_maybe[dname] == nil then
-								drop_maybe[dname] = 0
-							end
-							drop_maybe[dname] = drop_maybe[dname] + dcount
-						end
-					end
-				end
-			end
-			for itemstring, count in pairs(drop_guaranteed) do
-				ui.register_craft({
-					type = "digging",
-					items = {name},
-					output = itemstring .. " " .. count,
-					width = 0,
-				})
-			end
-			for itemstring, count in pairs(drop_maybe) do
-				ui.register_craft({
-					type = "digging_chance",
-					items = {name},
-					output = itemstring .. " " .. count,
-					width = 0,
-				})
-			end
-		end
-	end
-
 	-- Step 1: Initialize cache for looking up groups
 	unified_inventory.init_matching_cache()
+
+	-- Index all craftable craft recipes. This depends on 'init_matching_cache'
+	register_normal_craft_recipes()
+	for _, name in ipairs(ui.items_list) do
+		register_dig_drops(name)
+	end
 
 	-- Step 2: Find all matching items for the given spec (groups)
 	local get_matching_spec_items = unified_inventory.get_matching_items

--- a/group.lua
+++ b/group.lua
@@ -11,60 +11,28 @@ function unified_inventory.extract_groupnames(groupname)
 end
 
 
--- This is used when displaying craft recipes, where an ingredient is
--- specified by group rather than as a specific item.  A single-item group
--- is represented by that item, with the single-item status signalled
--- in the "sole" field.  If the group contains no items at all, the item
--- field will be nil.
---
--- Within a multiple-item group, we prefer to use an item that has the
--- same specific name as the group, and if there are more than one of
--- those items we prefer the one registered for the group by a mod.
--- Among equally-preferred items, we just pick the one with the
--- lexicographically earliest name.
---
--- The parameter to this function isn't just a single group name.
--- It may be a comma-separated list of group names.  This is really a
--- "group:..." ingredient specification, minus the "group:" prefix.
-
--- TODO Replace this with the more efficient spec matcher (below)
+--- @brief See documentation of `unified_inventory.get_group_item`
+---        Used in the craft guide to show a group item
 local function compute_group_item(group_name_list)
-	local group_names = group_name_list:split(",")
-	local candidate_items = {}
-	for itemname, itemdef in pairs(minetest.registered_items) do
-		if (itemdef.groups.not_in_creative_inventory or 0) == 0 then
-			local all = true
-			for _, group_name in ipairs(group_names) do
-				if (itemdef.groups[group_name] or 0) == 0 then
-					all = false
-				end
-			end
-			if all then table.insert(candidate_items, itemname) end
-		end
-	end
-	local num_candidates = #candidate_items
-	if num_candidates == 0 then
-		return {sole = true}
-	elseif num_candidates == 1 then
-		return {item = candidate_items[1], sole = true}
-	end
+	local candidate_items = ui.get_matching_items("group:" .. group_name_list)
+
 	local is_group = {}
-	local registered_rep = {}
-	for _, group_name in ipairs(group_names) do
+	for _, group_name in ipairs(group_name_list:split(",")) do
 		is_group[group_name] = true
-		local rep = unified_inventory.registered_group_items[group_name]
-		if rep then registered_rep[rep] = true end
 	end
-	local bestitem = ""
+
+	local count = 0
+	local bestitem
 	local bestpref = 0
-	for _, item in ipairs(candidate_items) do
+	for item, _ in pairs(candidate_items) do
+		count = count + 1
+
 		local pref
-		if registered_rep[item] then
-			pref = 4
-		elseif string.sub(item, 1, 8) == "default:" and is_group[string.sub(item, 9)] then
+		if string.sub(item, 1, 8) == "default:" and is_group[string.sub(item, 9)] then
 			-- TODO: Rank according to the mod load order but as of 5.15.0 there is no such API.
 			pref = 3
 		elseif is_group[item:gsub("^[^:]*:", "")] then
+			-- The item name happens to match the group name
 			pref = 2
 		else
 			pref = 1
@@ -74,7 +42,11 @@ local function compute_group_item(group_name_list)
 			bestpref = pref
 		end
 	end
-	return {item = bestitem, sole = false}
+
+	return {
+		item = bestitem, -- may be nil
+		sole = (count <= 1)
+	}
 end
 
 
@@ -84,6 +56,7 @@ local group_item_cache = {}
 ---        Use-case: get an image for recipe ingredients that are a group.
 --- @param group_name string, e.g. "tree,flammable"
 --- @return A table: `{ item = "mymod:best_fit", sole = boolean }`
+---         When `sole == true` --> no "G" (group) button text
 function unified_inventory.get_group_item(group_name)
 	if not group_item_cache[group_name] then
 		group_item_cache[group_name] = compute_group_item(group_name)
@@ -92,23 +65,27 @@ function unified_inventory.get_group_item(group_name)
 end
 
 
+-- { group1 = { ["item:name1"] = true, ... }, group2 =  .... }
+local group_to_item_list = {}
+local group_LUT_initialized = false
+
 --[[
 This is for filtering known items by groups
 e.g. find all items that match "group:flower,yellow" (flower AND yellow groups)
 ]]
-local spec_matcher = {}
 function unified_inventory.init_matching_cache()
 	for _, name in ipairs(ui.items_list) do
 		-- we only need to care about groups, exact items are handled separately
 		for group, value in pairs(minetest.registered_items[name].groups) do
 			if value and value ~= 0 then
-				if not spec_matcher[group] then
-					spec_matcher[group] = {}
+				if not group_to_item_list[group] then
+					group_to_item_list[group] = {}
 				end
-				spec_matcher[group][name] = true
+				group_to_item_list[group][name] = true
 			end
 		end
 	end
+	group_LUT_initialized = true
 end
 
 --[[
@@ -124,22 +101,26 @@ Output:
 	}
 ]]
 function unified_inventory.get_matching_items(specname)
+	assert(group_LUT_initialized) -- Function must not be called too early.
+
 	if specname:sub(1,6) ~= "group:" then
 		return { [specname] = true }
 	end
 
 	local accepted = {}
 	for i, group in ipairs(specname:sub(7):split(",")) do
+		local item_list = group_to_item_list[group]
 		if i == 1 then
 			-- First step: Copy all possible item names in this group
-			for name, _ in pairs(spec_matcher[group] or {}) do
+			for name, _ in pairs(item_list or {}) do
 				accepted[name] = true
 			end
 		else
 			-- Perform filtering
-			if spec_matcher[group] then
+			if item_list then
 				for name, _ in pairs(accepted) do
-					accepted[name] = spec_matcher[group][name]
+					-- Is set to `nil` if the group is missing
+					accepted[name] = item_list[name]
 				end
 			else
 				-- No matching items


### PR DESCRIPTION
* Unify some of the duplicated group handling code.
* Move separate init steps to their own functions.

The item drops code was only moved to a separate function without logic changes.

This is a rather large change, thus opened a PR for reviewing.