### PR TITLE
Support multiple craft outputs

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -2,6 +2,8 @@ local S = minetest.get_translator("unified_inventory")
 local F = minetest.formspec_escape
 local ui = unified_inventory
 
+local recipes_initialized = false
+
 --- @return boolean. Returns `true` when all ingredients exist.
 local function is_recipe_craftable(recipe)
 	-- Ensure the ingedients exist
@@ -201,6 +203,7 @@ minetest.after(0.01, function()
 		end
 		ui.crafts_for.recipe[outputitemname] = new_recipe_list
 	end
+	recipes_initialized = true
 
 	-- Remove unknown items from all categories
 	local total_removed = 0
@@ -292,6 +295,15 @@ function ui.register_craft(options)
 		return
 	end
 
+	if recipes_initialized then
+		-- If you're getting this warning, do use either:
+		--   a)  unified_inventory.register_craft(...)
+		--   b)  core.register_on_mods_loaded(...)
+		core.log("warning", "[unified_inventory] Recipe registered too late: " ..
+			dump(options.output):gsub("[\t\n]", " ") ..
+			". It might not show up correctly.")
+	end
+
 	if options.type == "normal" and options.width == 0 then
 		options = {
 			type = "shapeless",
@@ -308,7 +320,7 @@ function ui.register_craft(options)
 			-- Most common
 			outputs = { outputs }
 		elseif type(outputs) == "userdata" and outputs.add_item then
-			-- Rare
+			-- Rare: ItemStack
 			outputs = { outputs }
 		end
 		assert(type(outputs) == "table", "Invalid 'output' field: " .. type(options.output))

--- a/doc/mod_api.txt
+++ b/doc/mod_api.txt
@@ -12,6 +12,9 @@ API revisions within unified_inventory can be checked using:
 
 * Version `1`: Classic formspec layout (no real_coordinates)
 * Version `2`: Force formspec version 4 (includes real_coordinates)
+* Version `5` (Y2025): unified_inventory_hide_uncraftable_items
+* Version `6` (Y2026): Support for multiple craft outputs
+
 
 Misc functions
 --------------
@@ -48,24 +51,31 @@ These methods should be used instead of accessing the unified_inventory data str
 
 Get a list of recipes for a particular output item:
 
-	unified_inventory.get_recipe_list(output_item)
+	unified_inventory.get_recipe_list2(output_item)
 
 	Returns a list of tables, each holding a recipe definition, like:
 	{
 		{
 			type = "normal",
 			items = { "default:stick", "default:stick", "default:stick", "default:stick" },
-			output = "default:wood",
+			output = { ItemStack("default:wood") },
 			width = 2
 		},
 		{
 			type = "shapeless",
 			items = { "default:tree" },
-			output = "default:wood 4",
+			output = { ItemStack("default:wood 4"), ItemStack("mynaturemod:resin 2") },
 			width = 0
 		},
 		...
 	}
+
+ * `unified_inventory.get_recipe_list(output_item)`
+     * This function is depreacted and will be removed in future releases.
+     * Returns a list of recipes like `unified_inventory.get_recipe_list2` but does not
+       contain recipes with multiple outputs.
+     * The `output` field is of the type `string` (e.g. `default:stick 3`).
+
 
 Get a list of all the output items crafts have been registered for:
 
@@ -159,7 +169,7 @@ Register a non-standard craft recipe:
 			{ "default:bar" }
 		},
 		width = 3,
-		-- ^ Same as `minetest.register_recipe`
+		-- ^ Same as `core.register_craft`
 	})
 
 
@@ -206,7 +216,7 @@ Modifier functions (to be removed)
 
 Item management
 
- * `	unified_inventory.add_category_item(name, itemname)`
+ * `unified_inventory.add_category_item(name, itemname)`
      * Adds a single item to the category
      * `itemname` (string): self-explanatory
  * `unified_inventory.add_category_items(name, { itemname1, itemname2, ... }`

--- a/init.lua
+++ b/init.lua
@@ -58,7 +58,7 @@ unified_inventory = {
 	hide_disabled_buttons = minetest.settings:get_bool("unified_inventory_hide_disabled_buttons", false),
 	hide_uncraftable_items = minetest.settings:get_bool("unified_inventory_hide_uncraftable_items", false),
 
-	version = 5
+	version = 6
 }
 
 local ui = unified_inventory
@@ -204,3 +204,5 @@ if minetest.settings:get_bool("unified_inventory_waypoints") ~= false then
 	dofile(modpath.."/waypoints.lua")
 end
 dofile(modpath.."/legacy.lua") -- mod compatibility
+
+--dofile(modpath.."/unittests.lua") -- For development purposes only!

--- a/internal.lua
+++ b/internal.lua
@@ -365,9 +365,10 @@ function ui.apply_filter(player, filter, search_dir)
 	local fprefilter = function(_)
 		return true
 	end
+
 	if ui.hide_uncraftable_items and not ui.is_creative(player_name) then
 		fprefilter = function(name)
-			return ui.get_recipe_list(name)
+			return ui.get_recipe_list2(name)
 		end
 	end
 

--- a/register.lua
+++ b/register.lua
@@ -344,9 +344,14 @@ ui.register_page("craftguide", {
 				formspec[n+3] = giveme_form
 			end
 			return { formspec = table.concat(formspec) }
-		else
-			formspec[n] = stack_image_button(craftguideresultx, craftguidey, 1.2, 1.2,
-					"item_button_" .. rdir .. "_", ItemStack(craft.output))
+		end
+
+		-- List all recipes
+		for i = #craft.output, 1, -1 do
+			-- Go in reverse to not overlap the stack count
+			local itemstack = craft.output[i]
+			formspec[n] = stack_image_button(craftguideresultx + (i - 1) * 0.8, craftguidey, 1.2, 1.2,
+					"item_button_" .. rdir .. "_", itemstack)
 			n = n + 1
 		end
 

--- a/unittests.lua
+++ b/unittests.lua
@@ -1,0 +1,72 @@
+core.log("error", "[unified_inventory] Unittests are enabled!")
+
+local ui = unified_inventory
+
+core.register_craftitem(":uitest:leaves", {
+	description = "UITEST Leaves",
+	inventory_image = "default_leaves.png",
+})
+
+core.register_craftitem(":uitest:apple", {
+	description = "UITEST Apple",
+	inventory_image = "default_apple.png",
+})
+
+core.register_craftitem(":uitest:stick", {
+	description = "UITEST Stick",
+	inventory_image = "default_stick.png",
+})
+
+do
+	ui.register_craft({
+		type = "digging_chance",
+		items = {"uitest:leaves"},
+		output = ItemStack("uitest:apple 2"),
+		width = 0,
+	})
+	ui.register_craft({
+		type = "digging_chance",
+		items = {"uitest:leaves"},
+		output = { ItemStack("uitest:apple 1"), "uitest:stick 3" },
+		width = 0,
+	})
+end
+
+local function find_recipe_output(recipes, output)
+	for _, recipe in ipairs(recipes) do
+		if type(recipe.output) == "table" then
+			-- get_recipe_list2(..)
+			for _, itemstack in ipairs(recipe.output) do
+				if itemstack:to_string() == output then
+					return recipe
+				end
+			end
+		else
+			-- get_recipe_list(..)
+			if recipe.output == output then
+				return recipe
+			end
+		end
+	end
+	return nil
+end
+
+local function run_tests()
+	local list, match
+
+	list = ui.get_recipe_list2("uitest:apple")
+	assert(#list == 2)
+	match = assert(find_recipe_output(list, "uitest:stick 3"))
+	assert(match.items[1] == "uitest:leaves")
+
+	-- Backwards compat
+	list = ui.get_recipe_list("uitest:apple")
+	assert(#list == 1)
+	match = assert(find_recipe_output(list, "uitest:apple 2"))
+	assert(match.items[1] == "uitest:leaves")
+
+	-- Done
+	error("Tests passed!")
+end
+
+core.after(1, run_tests)


### PR DESCRIPTION
Fixes #260
Should fix #263

Unfortunately there's currently only space for about 1.7 output buttons, thus with two outputs it looks like this:

<img width="520" height="252" alt="grafik" src="https://github.com/user-attachments/assets/4cde2bb6-5f3f-47b6-83c3-c4acd8ee2e98" />

With three or more outputs it'll certainly overflow into the item browser. That will be addressed in a separate PR / commit.

@The4codeblocks @olivia-may If you happen to have time - would you please be so nice to check whether this PR works as intended?