### PR TITLE
Add negative filter groups when the search box is empty

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -51,8 +51,6 @@ unified_inventory = {
 		"background9[0,0;1,1;ui_formbg_9_sliced.png;true;16]"
 	),
 
-	hide_groups_ifempty = { "stair" }, -- TODO: make customizable
-
 	version = 7
 }
 

--- a/init.lua
+++ b/init.lua
@@ -51,6 +51,8 @@ unified_inventory = {
 		"background9[0,0;1,1;ui_formbg_9_sliced.png;true;16]"
 	),
 
+	hide_groups_ifempty = { "stair" }, -- TODO: make customizable
+
 	version = 7
 }
 

--- a/internal.lua
+++ b/internal.lua
@@ -366,12 +366,18 @@ function ui.apply_filter(player, filter)
 	local fgroupfilter = function(_)
 		return true
 	end
-	if #ui.hide_groups_ifempty > 0 then
+	local blacklist_groups = string.split(ui.get_setting(player_name, "hide_groups_ifempty"), ",")
+	if #blacklist_groups > 0 then
+		for i, group in ipairs(blacklist_groups) do
+			-- Remove spaces around the group string
+			blacklist_groups[i] = string.trim(group)
+		end
+
 		fgroupfilter = function(def)
 			if #filter > 0 then
 				return true
 			end
-			for _, group in ipairs(ui.hide_groups_ifempty) do
+			for _, group in ipairs(blacklist_groups) do
 				if (def.groups[group] or 0) ~= 0 then
 					return false
 				end

--- a/internal.lua
+++ b/internal.lua
@@ -363,6 +363,25 @@ function ui.apply_filter(player, filter)
 		end
 	end
 
+	local fgroupfilter = function(_)
+		return true
+	end
+	if #ui.hide_groups_ifempty > 0 then
+		fgroupfilter = function(def)
+			if #filter > 0 then
+				return true
+			end
+			for _, group in ipairs(ui.hide_groups_ifempty) do
+				if (def.groups[group] or 0) ~= 0 then
+					return false
+				end
+			end
+			return true
+		end
+	end
+
+	-- 'ui.items_list' is created after ServerEnvironment has started. Hence, all items
+	-- in that list must be registered and found in 'core.registered_items'.
 	local registered_items = core.registered_items
 	local lfilter = string.lower(filter)
 	local ffilter
@@ -372,13 +391,8 @@ function ui.apply_filter(player, filter)
 		local groups = lfilter:sub(7):split(",")
 		ffilter = function(name)
 			local def = registered_items[name]
-			if not def then
-				return false
-			end
-
 			for _, group in ipairs(groups) do
-				if not def.groups[group]
-				or def.groups[group] <= 0 then
+				if (def.groups[group] or 0) == 0 then
 					return false
 				end
 			end
@@ -394,17 +408,16 @@ function ui.apply_filter(player, filter)
 
 		ffilter = function(name)
 			local def = registered_items[name]
-			if not def then
+			if not fgroupfilter(def) then
 				return false
 			end
 
 			local lname = string.lower(name)
 			-- Strip escapes to only match visible text (and not textdomains)
 			local ldesc = string.lower(strip_escapes(def.description))
-			local llocaldesc = core.get_translated_string
-				and string.lower(core.get_translated_string(lang, def.description))
+			local llocaldesc = string.lower(core.get_translated_string(lang, def.description))
 			return string.find(lname, lfilter, 1, true) or string.find(ldesc, lfilter, 1, true)
-				or llocaldesc and string.find(llocaldesc, lfilter, 1, true)
+				or string.find(llocaldesc, lfilter, 1, true)
 		end
 	end
 
@@ -435,7 +448,6 @@ function ui.apply_filter(player, filter)
 			end
 		end
 	end
-	table.sort(filtered_items)
 
 	ui.filtered_items_list_size[player_name] = #filtered_items
 	ui.filtered_items_list[player_name] = filtered_items

--- a/settings.lua
+++ b/settings.lua
@@ -5,12 +5,20 @@ local settings = {
 		conf_value = core.settings:get_bool("unified_inventory_lite", false),
 		-- title
 		-- desc
+		-- (values)
 	},
 	hide_disabled_buttons = {
 		conf_value = core.settings:get_bool("unified_inventory_hide_disabled_buttons", false),
 	},
 	hide_uncraftable_items = {
 		conf_value = core.settings:get_bool("unified_inventory_hide_uncraftable_items", false),
+	},
+	hide_groups_ifempty = {
+		conf_value = "stair",
+		title = "Automatically hidden groups",
+		desc = "Comma-separated list of groups to hide from the item browser " ..
+			"when no filter is applied (i.e. empty search box).",
+		values = "group1, group2, ...",
 	},
 }
 
@@ -76,6 +84,7 @@ local function on_setting_changed(player_name, old, new)
 		return
 	end
 	local player = core.get_player_by_name(player_name)
+	ui.apply_filter(player, ui.current_searchbox[player_name])
 	ui.set_inventory_formspec(player, ui.current_page[player_name])
 end
 
@@ -85,11 +94,12 @@ local function register_playersettings()
 	for key, def in pairs(settings) do
 		--print("register", key, dump(def))
 		playersettings.register("unified_inventory:" .. key, {
-			type = "boolean",
+			type = type(def.conf_value),
 			shortdesc = "Unified Inventory: " .. def.title,
 			longdesc  = def.desc,
 			default   = def.conf_value,
 			afterchange = on_setting_changed,
+			values = def.values
 		})
 	end
 end


### PR DESCRIPTION
By default, this now blacklists nodes with the 'stair' group.

Requested here: https://forum.luanti.org/viewtopic.php?p=450935#p450935

This feature become a per-player setting. Server owners may also change moreblocks to hide all recipes from the craft guide.