### PR TITLE
Display group item count

### DIFF
--- a/register.lua
+++ b/register.lua
@@ -183,6 +183,9 @@ local function stack_image_button(x, y, w, h, buttonname_prefix, item)
 		local group_item = ui.get_group_item(group_name)
 		show_is_group = not group_item.sole
 		displayitem = group_item.item or name
+		if item:get_count() > 1 then
+			displayitem = displayitem.." "..item:get_count()
+		end
 		selectitem = group_item.sole and displayitem or name
 	end
 	local label = show_is_group and "G" or ""


### PR DESCRIPTION
Adds the item count to the group item displayed in recipes.

Use case: https://github.com/mt-mods/technic/pull/441